### PR TITLE
install chrome directly for quarto rendering (for webshot)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -58,7 +58,8 @@ jobs:
           # (for example, browser/rendering and build helpers such as `chromium`,
           # `cmake`, `libgit2-dev`, `libnode-dev`, `libx11-dev`, and `pandoc`),
           # so the full list here is intentionally broader than publish/lint.
-          sudo apt-get install -y jags libcurl4-openssl-dev libpng-dev libfontconfig1-dev libjpeg-dev libglpk-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libtiff5-dev libwebp-dev libnode109 chromium cmake libgit2-dev libnode-dev libx11-dev pandoc
+          sudo apt-get install -y jags libcurl4-openssl-dev libpng-dev libfontconfig1-dev libjpeg-dev libglpk-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libtiff5-dev libwebp-dev libnode109 cmake libgit2-dev libnode-dev libx11-dev pandoc
+          
 
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,6 +60,9 @@ jobs:
           # so the full list here is intentionally broader than publish/lint.
           sudo apt-get install -y jags libcurl4-openssl-dev libpng-dev libfontconfig1-dev libjpeg-dev libglpk-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libtiff5-dev libwebp-dev libnode109 chromium cmake libgit2-dev libnode-dev libx11-dev pandoc
 
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+  
       - uses: r-lib/actions/setup-renv@v2
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jags libcurl4-openssl-dev libpng-dev libfontconfig1-dev libjpeg-dev libglpk-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libtiff5-dev libwebp-dev libnode109
 
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+
       - uses: r-lib/actions/setup-renv@v2
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to ensure that Google Chrome is reliably available in both the preview and publish workflows. The main change is the addition of a dedicated Chrome setup step using the `browser-actions/setup-chrome` action.

**Workflow improvements:**

* Added a `Setup Chrome` step to `.github/workflows/preview.yml` using `browser-actions/setup-chrome@v1` to ensure Chrome is available for tests or scripts that require it.
* Added a `Setup Chrome` step to `.github/workflows/publish.yml` using `browser-actions/setup-chrome@v1` for consistent Chrome setup in the publish workflow.