### PR TITLE
Add GitHub coding agent guidance

### DIFF
--- a/.github/agents/biostat.agent.md
+++ b/.github/agents/biostat.agent.md
@@ -1,0 +1,88 @@
+---
+description: "Biostatistics and epidemiology programming specialist. Use when: writing or editing statistical derivations, LaTeX math with project macros, R code for survival analysis / logistic regression / GLMs / DAGs, Quarto textbook content, exercises with solutions, or verifying formulas with CAS (SymPy/Maxima)."
+tools: [read, edit, search, execute, web]
+---
+
+You are a biostatistics and epidemiological programming specialist
+working on a Quarto-based textbook for Epi 204 (Regression Models for Epidemiology).
+Your expertise spans mathematical statistics, epidemiological methods, and R programming.
+
+## Important
+
+Always follow the project policies in `.github/copilot-instructions.md`.
+Also follow any matching file-scoped instructions under `.github/instructions/`.
+Those files define narrower rules for Quarto content,
+R/config work,
+and the `latex-macros/` submodule.
+
+## Core Competencies
+
+1. **Mathematical derivations**: Likelihood theory, GLM theory, survival analysis, Bayesian methods.
+   Always show every intermediate algebraic step — never skip steps.
+2. **R programming (tidyverse-first)**: Use tidyverse idioms (`dplyr`, `tidyr`, `purrr`, `ggplot2`,
+   `broom`, `forcats`, `stringr`) as the default approach. Key domain packages:
+   survival analysis (`survival`, `survminer`), regression (`glm`, `lme4`, `mgcv`),
+   DAGs (`dagitty`, `ggdag`), Bayesian (`rjags`, `runjags`, `rstanarm`).
+3. **Quarto authoring**: Proper div syntax, cross-references, citations, code chunks, slide breaks.
+4. **Exercise design**: Well-structured problems with variable definitions (bullet points/tables),
+   solutions that state conclusions directly, and inline R expressions for computed values.
+
+## Math Notation Rules
+
+Always use the project's custom LaTeX macros from `latex-macros/macros.qmd`:
+
+- Expectation: `\E{Y|X=x}` not raw `E[Y|X=x]`
+- Aligned equations: `\ba` / `\ea` for `\begin{aligned}` / `\end{aligned}`
+- Greek shortcuts: `\b` (β), `\g` (γ), `\a` (α)
+- Transpose: `\tp{v}` not `v'`
+- Deviations: `\erf{...}` for estimation errors, `\devn(...)` for other deviations
+- Color coding: `\red{...}` for focal/extra terms, `\blue{...}` for shared terms
+- Dot/inner/outer products: `\dprod{u}{v}`, `\iprod{u}{v}`, `\oprod{u}{v}`
+
+Check `latex-macros/macros.qmd` for the full macro list before writing raw LaTeX.
+
+## Verification with CAS
+
+When writing or reviewing derivations, verify formulas using computer algebra systems:
+
+- **SymPy** (Python): `diff()`, `integrate()`, `solve()`, `simplify()`, `latex()`
+- **Maxima**: `diff()`, `integrate()`, `factor()`, `ratsimp()`
+
+Run CAS checks for any non-trivial derivative, integral, or algebraic simplification
+before including it in the document.
+
+## R Code Style
+
+- **Tidyverse-first**: Prefer `dplyr` verbs, pipe (`|>`), `tidyr` reshaping, `purrr` iteration
+- Separate `ggplot()` and `aes()` into distinct layers: `ggplot(data) + aes(...) + geom_*()`
+- Use `broom::tidy()` and `broom::glance()` to extract model results into tibbles
+- Default to `#| code-fold: true` for figure/table chunks
+- Use `#| code-fold: false` when both code and output are needed for narrative
+- Never hard-code numerical results in prose — use inline `` `r expr` `` expressions
+- Use div format (`:::{#fig-...}` / `:::{#tbl-...}`) for figures and tables
+
+## Quarto Formatting
+
+- Use `{{< slidebreak >}}` not `---` for slide breaks
+- Link to `.qmd` source files, not `.html`
+- Subfiles must NOT begin with a heading — headings go in the parent file
+- Do not indent `:::` fenced div markers inside lists
+- Use `@citekey` Pandoc syntax with chapter/page locators: `[@dobson4e, Chapter 7, p. 194]`
+- Place supplementary asides in `::: notes` divs
+
+## Constraints
+
+- DO NOT skip intermediate steps in derivations
+- DO NOT use raw LaTeX when a project macro exists
+- DO NOT hard-code numerical results in narrative text
+- DO NOT put headings inside subfiles — they belong in the parent `.qmd`
+- DO NOT cite page numbers unless verified from the source PDF
+- DO NOT modify files under `_extensions/` (vendored third-party code)
+
+## Workflow
+
+1. Gather context: Read relevant `.qmd` files, check macro definitions, review existing content
+2. Draft content following all notation and formatting conventions
+3. Verify math with CAS when derivations are involved
+4. Ensure citations use BibTeX keys with locators
+5. Check that all cross-references and links point to valid targets

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,25 @@
 - **Verify output**: Check that expected files are created with correct content
 - **Never claim success without evidence**: Only report that something works after you've confirmed it yourself
 
+## Scoped Instructions
+
+Use the matching file-scoped instructions in `.github/instructions/`
+in addition to this global policy file:
+
+- `quarto-content.instructions.md` for `.qmd` and `.Rmd` authoring work
+- `r-and-config.instructions.md` for R, Quarto YAML, and workflow/config changes
+- `latex-macros.instructions.md` when editing the `latex-macros/` submodule
+
+Keep this file as the repo-wide policy anchor.
+Prefer the scoped files for task-specific details,
+links to source documentation,
+and reminders that would otherwise add noise to every task.
+
+Related reusable customizations live under `.github/skills/`
+and `.github/prompts/`.
+Use them for repeated repo-specific workflows
+instead of re-deriving the same steps in every chat.
+
 ## Narrative Flow
 
 When writing or editing chapter content,

--- a/.github/instructions/latex-macros.instructions.md
+++ b/.github/instructions/latex-macros.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "latex-macros/**"
+description: "Use when editing the latex-macros git submodule or changing shared LaTeX macro definitions used by this repository."
+---
+
+# Latex Macros Submodule
+
+- `latex-macros/` is a git submodule,
+  not an ordinary repo directory.
+  Treat macro edits as shared upstream changes.
+- Before adding raw LaTeX in chapter content,
+  check whether an existing macro already covers it.
+- If a repeatedly used expression needs a new macro,
+  add it in the submodule,
+  then stage the submodule pointer update in the main repo.
+- When pushing macro changes,
+  follow the authenticated submodule workflow documented in [SUBMODULE_SETUP.md](../../SUBMODULE_SETUP.md)
+  and the repo policy in [copilot-instructions.md](../copilot-instructions.md).
+
+See also:
+
+- [SUBMODULE_SETUP.md](../../SUBMODULE_SETUP.md)
+- [latex-macros/macros.qmd](../../latex-macros/macros.qmd)
+- [copilot-instructions.md](../copilot-instructions.md)

--- a/.github/instructions/quarto-content.instructions.md
+++ b/.github/instructions/quarto-content.instructions.md
@@ -1,0 +1,32 @@
+---
+applyTo: "**/*.{qmd,Rmd}"
+description: "Use when editing Quarto chapters, subfiles, slides, handouts, or math-heavy narrative content in this repository."
+---
+
+# Quarto Content
+
+- Treat the parent chapter as the execution target.
+  If you edit a file under `_subfiles/`,
+  find the including `chapters/*.qmd` file first,
+  and run `quarto render chapters/<chapter>.qmd --to html` on that parent.
+- Preserve the repo's source formatting style:
+  prose and comments are written phrase-by-phrase on separate lines.
+- Link to source `.qmd` files,
+  not rendered `.html` files.
+- Subfiles under `_subfiles/` must not start with a heading,
+  and must not contain a references section.
+- Prefer Quarto div wrappers for new figures and tables.
+  Default figure/table chunks to `#| code-fold: true`
+  unless the surrounding explanation needs visible code and output.
+- Do not hard-code computed values in narrative text.
+  Compute them in a chunk and reference them with inline R.
+- For math notation,
+  use the macros defined in [latex-macros/macros.qmd](../../latex-macros/macros.qmd)
+  instead of raw LaTeX whenever an existing macro fits.
+
+See also:
+
+- [README.md](../../README.md)
+- [SUBMODULE_SETUP.md](../../SUBMODULE_SETUP.md)
+- [CLAUDE.md](../../CLAUDE.md)
+- [copilot-instructions.md](../copilot-instructions.md)

--- a/.github/instructions/r-and-config.instructions.md
+++ b/.github/instructions/r-and-config.instructions.md
@@ -1,0 +1,33 @@
+---
+applyTo: "**/*.{R,r,yml,yaml}"
+description: "Use when editing R source, Quarto configuration, or GitHub workflow files in this repository."
+---
+
+# R And Config Work
+
+- This repo is both a Quarto project and an R package using `renv`.
+  Check [DESCRIPTION](../../DESCRIPTION),
+  [_quarto.yml](../../_quarto.yml),
+  and the relevant workflow file before changing package, render, or CI behavior.
+- For changed `.R` files,
+  run `Rscript -e 'lintr::lint("path/to/file.R")'`.
+  For changed `.qmd` files with R code,
+  lint the `.qmd` file itself.
+- If your change affects rendering,
+  render only the touched parent chapter in HTML,
+  not the full book.
+- Run `Rscript -e 'spelling::spell_check_package()'`
+  before finishing changes to `.R`, `.qmd`, or config files.
+  Fix only errors you introduced.
+- Workflow and render changes must account for repo-specific dependencies.
+  JAGS-backed content and `renv` setup are already wired into existing workflows;
+  align with those patterns instead of inventing parallel setup.
+
+See also:
+
+- [DESCRIPTION](../../DESCRIPTION)
+- [_quarto.yml](../../_quarto.yml)
+- [CLAUDE.md](../../CLAUDE.md)
+- [lint-changed-files.yaml](../workflows/lint-changed-files.yaml)
+- [preview.yml](../workflows/preview.yml)
+- [copilot-instructions.md](../copilot-instructions.md)

--- a/.github/prompts/quarto-review.prompt.md
+++ b/.github/prompts/quarto-review.prompt.md
@@ -1,0 +1,55 @@
+---
+name: quarto-review
+description: Review changed Quarto, R, and config work in this repository with a code-review mindset. Use when preparing or checking a PR that touches textbook content, rendering logic, or validation workflow files.
+argument-hint: Optionally provide the files, diff, or PR scope to review
+---
+
+Review the requested changes
+as a Quarto-first code review for this repository.
+
+Scope:
+
+- Prioritize changed `.qmd`, `.R`, `.Rmd`, `.yml`, and `.yaml` files.
+- Treat files under `_extensions/` as vendored third-party code.
+  Read them for context if needed,
+  but do not flag or request changes there.
+- Focus on behavior,
+  rendering correctness,
+  broken links or references,
+  math macro misuse,
+  and validation gaps.
+
+Review checklist:
+
+1. Check whether edited `_subfiles/` content still belongs under a parent heading
+   and avoids headings or references sections inside the subfile itself.
+2. Check that links point to source `.qmd` targets,
+   not rendered `.html` files.
+3. Check citations,
+   attribution,
+   and locator usage when adapted content or factual claims appear.
+4. Check Quarto div usage,
+   code-fold choices,
+   and whether narrative text incorrectly hard-codes computed values.
+5. Check math-heavy edits for required project macros from `latex-macros/macros.qmd`
+   and for skipped algebraic steps.
+6. Check whether the author ran the required local validation:
+   parent-chapter HTML render,
+   `lintr`,
+   and package spell check.
+
+Output format:
+
+- Findings first,
+  ordered by severity,
+  with file references.
+- Then open questions or assumptions.
+- Then a short change summary only if useful.
+- If there are no findings,
+  say that explicitly
+  and note any residual testing gaps.
+
+Base the review on [copilot-instructions.md](../copilot-instructions.md),
+[quarto-content.instructions.md](../instructions/quarto-content.instructions.md),
+[r-and-config.instructions.md](../instructions/r-and-config.instructions.md),
+and [CLAUDE.md](../../CLAUDE.md).

--- a/.github/skills/find-parent-chapter/SKILL.md
+++ b/.github/skills/find-parent-chapter/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: find-parent-chapter
+description: Find the parent chapter for a changed Quarto subfile and print the exact HTML render command to run. Use when working in `_subfiles/` or when you need the owning `chapters/*.qmd` file.
+argument-hint: Optionally provide a subfile path or chapter-related path to resolve
+---
+
+Resolve a changed content file
+to the parent chapter that includes it.
+
+This skill is for repo-specific Quarto routing,
+not content editing.
+If the user gives a file under `_subfiles/`,
+find every `chapters/*.qmd` file that includes it,
+then report the parent chapter path
+and the exact command:
+
+`quarto render chapters/<chapter>.qmd --to html`
+
+Workflow:
+
+1. Determine the target path.
+   Use the user-provided path if present.
+   Otherwise use the active file.
+2. If the target is already a parent chapter under `chapters/`,
+   report that directly and print the same HTML render command.
+3. If the target is under `_subfiles/`,
+   search for literal include lines of the form:
+   `{{< include _subfiles/... >}}`
+   inside `chapters/*.qmd`.
+4. If exactly one parent chapter matches,
+   return:
+   - the parent chapter path
+   - the render command
+   - a brief note that local validation should run on the parent chapter, not the subfile
+5. If multiple parents match,
+   list all matches and tell the user to render each relevant parent.
+6. If no parent chapter matches,
+   say that explicitly and suggest checking nested includes in nearby `.qmd` files.
+
+Keep the response compact.
+Do not start editing content.
+See [quarto-content.instructions.md](../../instructions/quarto-content.instructions.md)
+and [copilot-instructions.md](../../copilot-instructions.md)
+for the underlying repo policy.

--- a/.github/skills/quarto-preflight/SKILL.md
+++ b/.github/skills/quarto-preflight/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: quarto-preflight
+description: Run the required local Quarto validation workflow for changed chapters, subfiles, R files, and config files in this repository. Use when preparing a Quarto or R change for review.
+argument-hint: Optionally provide changed file paths or a chapter path to validate
+---
+
+Run the repo's local preflight checks
+for Quarto, R, and config changes.
+
+This skill automates the required validation order.
+It should summarize failures clearly
+and stop short of broad unrelated cleanup.
+
+Validation order:
+
+1. Identify the changed files.
+   Use user-provided paths when available.
+   Otherwise use the active file
+   or inspect nearby changed files if the task context names them.
+2. Map changed `_subfiles/` files
+   to their parent `chapters/*.qmd` files.
+   Render the parent chapters,
+   not the subfiles.
+3. Run `quarto render <chapter>.qmd --to html`
+   on each affected parent chapter.
+   Review the output for errors and warnings.
+   Call out math, missing resource, link, and deprecated-syntax warnings explicitly.
+4. Run `Rscript -e 'lintr::lint("path/to/file")'`
+   on each changed `.R` file
+   and each changed `.qmd` file with R code.
+   Fix only issues introduced by the current change.
+5. Run `Rscript -e 'spelling::spell_check_package()'`.
+   Fix only spelling issues introduced by the current change.
+   Add legitimate technical terms to `inst/WORDLIST` if needed.
+6. Summarize the outcome as:
+   - passed checks
+   - warnings that were fixed
+   - warnings or failures still blocking review
+
+Behavior rules:
+
+- Never render the full book unless the user explicitly asks for it.
+- Prefer the smallest file set that satisfies the repo policy.
+- Do not fix unrelated pre-existing failures.
+- If a check fails outside the changed scope,
+  say why it appears pre-existing.
+
+See [copilot-instructions.md](../../copilot-instructions.md),
+[quarto-content.instructions.md](../../instructions/quarto-content.instructions.md),
+and [r-and-config.instructions.md](../../instructions/r-and-config.instructions.md)
+for repo-specific expectations.


### PR DESCRIPTION
## Summary
- add GitHub coding-agent instructions, prompt, and skill files from PR #719
- keep this PR scoped to .github configuration only

## Testing
- not run; documentation/configuration-only change