### PR TITLE
Re-request review from d-morrison after Claude runs on a PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -100,3 +100,13 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
+
+      - name: Re-request review from d-morrison
+        if: always() && (github.event.pull_request.number || github.event.issue.pull_request)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          gh api -X POST \
+            "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+            -f "reviewers[]=d-morrison" || true


### PR DESCRIPTION
POST /pulls/{N}/requested_reviewers re-adds the reviewer to the requested-reviewers list even if they have already submitted a review, which generates a fresh review-requested notification on every Claude run.