### PR TITLE
Re-request review only when Claude pushed new commits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -83,6 +83,16 @@ jobs:
         with:
           cache-version: 1
 
+      - name: Capture PR head SHA before Claude
+        id: head_before
+        if: github.event.pull_request.number || github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -101,12 +111,20 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
 
-      - name: Re-request review from d-morrison
-        if: always() && (github.event.pull_request.number || github.event.issue.pull_request)
+      - name: Re-request review from d-morrison if Claude pushed commits
+        if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA_BEFORE: ${{ steps.head_before.outputs.sha }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
-          gh api -X POST \
-            "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
-            -f "reviewers[]=d-morrison" || true
+          SHA_AFTER=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "before=$SHA_BEFORE  after=$SHA_AFTER"
+          if [ "$SHA_AFTER" != "$SHA_BEFORE" ]; then
+            echo "Claude pushed new commits; re-requesting review."
+            gh api -X POST \
+              "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+              -f "reviewers[]=d-morrison" || true
+          else
+            echo "No new commits on PR head; skipping re-request."
+          fi


### PR DESCRIPTION
## Summary
- Adds a `Capture PR head SHA before Claude` step that records the PR's head SHA before the action runs.
- Updates the existing `Re-request review` step to compare the captured SHA to the post-run head SHA and only POST to `/requested_reviewers` if the head moved.

## Why
Yesterday's change (#732) re-requested review on every Claude run, including ones where Claude failed before committing or just commented without pushing. This produced spurious review-request notifications (e.g., the failure on PR #719 still triggered a re-request because the step used `if: always()`).

The `if: always()` is retained so the comparison runs even when Claude fails — but with no head change, it logs "skipping re-request" and exits.

## Test plan
- [ ] Merge
- [ ] `@claude` on a PR with a no-op or failing prompt → confirm **no** review request
- [ ] `@claude do X` on a PR where Claude actually pushes a commit → confirm review **is** re-requested