### PR TITLE
Allow Rscript and quarto in @claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -109,7 +109,9 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Allow the pre-commit checklist tools from CLAUDE.md (Rscript for
+          # lint/spell-check, quarto render for chapter previews).
+          claude_args: '--allowed-tools "Bash(Rscript *),Bash(quarto *)"'
 
       - name: Re-request review from d-morrison if Claude pushed commits
         if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''


### PR DESCRIPTION
## Summary
- Uncomments `claude_args` in `.github/workflows/claude.yml` and sets `--allowed-tools "Bash(Rscript *),Bash(quarto *)"` so the `@claude` action can run the pre-commit checklist from `CLAUDE.md` (lintr, spelling, quarto render) without hitting an approval prompt it cannot answer.
- Motivated by #718, where Claude reported it could not finish the checklist because `Rscript` was not allow-listed.

## Test plan
- [ ] After merge, comment `@claude review and fix iteratively` on a test PR and confirm the action successfully runs `Rscript -e 'lintr::lint(...)'` and `quarto render ... --to html` without an approval-required failure.
- [ ] Confirm the action's default safe-tool allow-list is still in effect (e.g. `gh pr` reads still work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)