### PR TITLE
Allow @claude WebFetch to stats-allowlist domains

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -100,6 +100,9 @@ jobs:
         id: tools
         run: |
           curl -fsSL https://raw.githubusercontent.com/d-morrison/stats-allowlist/main/allowlist.txt -o /tmp/allowlist.txt
+          # Reject anything that isn't a strictly valid hostname so a typo or
+          # tampered upstream entry can't inject extra claude_args via " or
+          # other shell metacharacters.
           WEBFETCH=$(tr -d '\r' < /tmp/allowlist.txt \
             | grep -v '^[[:space:]]*$' \
             | grep -v '^[[:space:]]*#' \
@@ -107,10 +110,15 @@ jobs:
             | sed -E 's#/.*$##' \
             | sed -E 's#[^A-Za-z0-9.-]+$##' \
             | tr '[:upper:]' '[:lower:]' \
+            | grep -E '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$' \
             | sort -u \
             | sed 's#.*#WebFetch(domain:&)#' \
             | paste -sd, -)
-          echo "allowed=Bash(Rscript *),Bash(quarto *),${WEBFETCH}" >> "$GITHUB_OUTPUT"
+          if [ -n "$WEBFETCH" ]; then
+            echo "allowed=Bash(Rscript *),Bash(quarto *),${WEBFETCH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=Bash(Rscript *),Bash(quarto *)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -95,11 +95,21 @@ jobs:
 
       # Build a WebFetch permission list from the shared stats-allowlist repo
       # so Claude can read pages from d-morrison.github.io and other approved
-      # sites referenced in the book.
+      # sites referenced in the book. Trust model: anyone with push access to
+      # d-morrison/stats-allowlist@main can expand Claude's WebFetch scope on
+      # the next workflow run here. The hostname regex below ensures even a
+      # tampered entry can only widen WebFetch coverage, not inject other
+      # claude_args.
       - name: Build allowed-tools list from stats-allowlist
         id: tools
         run: |
-          curl -fsSL https://raw.githubusercontent.com/d-morrison/stats-allowlist/main/allowlist.txt -o /tmp/allowlist.txt
+          # Initialize to empty so a curl failure degrades gracefully to the
+          # base toolset (Bash only) rather than failing the whole @claude
+          # workflow with no PR feedback.
+          : > /tmp/allowlist.txt
+          curl -fsSL https://raw.githubusercontent.com/d-morrison/stats-allowlist/main/allowlist.txt \
+            -o /tmp/allowlist.txt \
+            || echo "::warning::Could not fetch stats-allowlist; running Claude without WebFetch permissions."
           # Reject anything that isn't a strictly valid hostname so a typo or
           # tampered upstream entry can't inject extra claude_args via " or
           # other shell metacharacters.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -93,6 +93,25 @@ jobs:
           SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
+      # Build a WebFetch permission list from the shared stats-allowlist repo
+      # so Claude can read pages from d-morrison.github.io and other approved
+      # sites referenced in the book.
+      - name: Build allowed-tools list from stats-allowlist
+        id: tools
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/d-morrison/stats-allowlist/main/allowlist.txt -o /tmp/allowlist.txt
+          WEBFETCH=$(tr -d '\r' < /tmp/allowlist.txt \
+            | grep -v '^[[:space:]]*$' \
+            | grep -v '^[[:space:]]*#' \
+            | sed -E 's#^[[:space:]]*https?://##' \
+            | sed -E 's#/.*$##' \
+            | sed -E 's#[^A-Za-z0-9.-]+$##' \
+            | tr '[:upper:]' '[:lower:]' \
+            | sort -u \
+            | sed 's#.*#WebFetch(domain:&)#' \
+            | paste -sd, -)
+          echo "allowed=Bash(Rscript *),Bash(quarto *),${WEBFETCH}" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -110,8 +129,9 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # Allow the pre-commit checklist tools from CLAUDE.md (Rscript for
-          # lint/spell-check, quarto render for chapter previews).
-          claude_args: '--allowed-tools "Bash(Rscript *),Bash(quarto *)"'
+          # lint/spell-check, quarto render for chapter previews) plus
+          # WebFetch for every host in the shared stats-allowlist.
+          claude_args: '--allowed-tools "${{ steps.tools.outputs.allowed }}"'
 
       - name: Re-request review from d-morrison if Claude pushed commits
         if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''


### PR DESCRIPTION
## Summary

- Pulls `d-morrison/stats-allowlist/allowlist.txt` at job time and converts each entry into a `WebFetch(domain:...)` permission for the `@claude` action.
- Lets Claude read pages on `d-morrison.github.io` and the other approved sites referenced in the book without per-domain workflow edits.
- Existing `Bash(Rscript *)` and `Bash(quarto *)` permissions are preserved.

## Test plan

- [ ] On a PR, comment `@claude` and confirm the workflow's `Build allowed-tools list from stats-allowlist` step succeeds and produces a non-empty `allowed` output.
- [ ] In a follow-up `@claude` comment, ask it to fetch a page from `https://d-morrison.github.io/...` and confirm the fetch is permitted (no permission prompt / no refusal).
- [ ] Spot-check the Claude run logs to confirm the assembled `--allowed-tools` value contains `WebFetch(domain:d-morrison.github.io)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)