### PR TITLE
Allow Bash(curl *) in @claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -125,9 +125,9 @@ jobs:
             | sed 's#.*#WebFetch(domain:&)#' \
             | paste -sd, -)
           if [ -n "$WEBFETCH" ]; then
-            echo "allowed=Bash(Rscript *),Bash(quarto *),${WEBFETCH}" >> "$GITHUB_OUTPUT"
+            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${WEBFETCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "allowed=Bash(Rscript *),Bash(quarto *)" >> "$GITHUB_OUTPUT"
+            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Claude Code
@@ -147,7 +147,8 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # Allow the pre-commit checklist tools from CLAUDE.md (Rscript for
-          # lint/spell-check, quarto render for chapter previews) plus
+          # lint/spell-check, quarto render for chapter previews), curl for
+          # downloading source PDFs too large for WebFetch (issue #740), plus
           # WebFetch for every host in the shared stats-allowlist.
           claude_args: '--allowed-tools "${{ steps.tools.outputs.allowed }}"'
 


### PR DESCRIPTION
## Summary

Adds \`Bash(curl *)\` to the @claude action's allowed-tools so Claude can download source PDFs that are too large for \`WebFetch\` (which has a 10 MB limit), save them to disk, and read specific page ranges. This unblocks citation verification against large references like Billingsley — see the case in [#719 (comment)](https://github.com/d-morrison/rme/pull/719#issuecomment-4465292043).

Closes #740.

## Test plan

- [ ] On a PR, comment \`@claude please curl https://example.com/some.pdf and tell me what's on page 5\` and confirm the run completes without a permission prompt for \`curl\`.
- [ ] Confirm existing \`Rscript\`, \`quarto\`, and \`WebFetch\` tool permissions still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)