### PR TITLE
Auto-trigger code review after @claude pushes commits

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,6 +9,16 @@ on:
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
+  # Allow claude.yml to dispatch a fresh review after the @claude run
+  # pushes commits. GITHUB_TOKEN-driven pushes don't fire `synchronize`,
+  # and even when they do the bot-actor filter below would skip the run,
+  # so we need an explicit dispatch path.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to review'
+        required: true
+        type: number
 
 # Serialize runs per PR. The stash/restore reviewer dance below assumes
 # only one run is mutating the PR's reviewer list at a time; without
@@ -16,12 +26,17 @@ on:
 # [], and on restore wipes the original reviewers permanently. Cancel
 # the in-flight run on a new push so the freshest diff wins.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
-    if: ${{ github.event.pull_request.user.type != 'Bot' && github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]') }}
+    # workflow_dispatch is only fired by claude.yml after it pushed commits,
+    # so we always want to run in that case; otherwise apply the usual
+    # bot-actor filter to skip Dependabot/Copilot/etc. PRs.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.user.type != 'Bot' && github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -29,6 +44,11 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    env:
+      # Resolve PR number once per job — populated by the pull_request event
+      # in the normal flow, or by the workflow_dispatch input when claude.yml
+      # triggered us after pushing commits.
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     permissions:
       contents: read
       pull-requests: write
@@ -52,7 +72,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           REVIEWERS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers")
           USERS=$(echo "$REVIEWERS_JSON" | jq -c '[.users[].login]')
@@ -73,7 +92,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           # Mirrors how anthropics/claude-code-action locates its sticky comment to update.
           # See create-initial.ts in:
           # https://github.com/anthropics/claude-code-action/tree/main/src/github/operations/comments
@@ -97,7 +115,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }}'
           # Force tag mode (anthropics/claude-code-action src/modes/detector.ts).
           # In the default agent mode for pull_request events, the action never
           # posts any non-inline PR comment by itself (src/modes/agent/index.ts:
@@ -124,7 +142,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           USERS: ${{ steps.stash.outputs.users }}
           TEAMS: ${{ steps.stash.outputs.teams }}
         run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -152,7 +152,7 @@ jobs:
           # WebFetch for every host in the shared stats-allowlist.
           claude_args: '--allowed-tools "${{ steps.tools.outputs.allowed }}"'
 
-      - name: Re-request review from d-morrison if Claude pushed commits
+      - name: Re-request review and dispatch code review if Claude pushed commits
         if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -162,10 +162,17 @@ jobs:
           SHA_AFTER=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "before=$SHA_BEFORE  after=$SHA_AFTER"
           if [ "$SHA_AFTER" != "$SHA_BEFORE" ]; then
-            echo "Claude pushed new commits; re-requesting review."
+            echo "Claude pushed new commits; re-requesting review and dispatching code review."
             gh api -X POST \
               "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
               -f "reviewers[]=d-morrison" || true
+            # Fire claude-code-review.yml via workflow_dispatch. The default
+            # GITHUB_TOKEN is permitted to trigger workflow_dispatch (unlike
+            # push, which is blocked to avoid recursion), and the review
+            # workflow's own `concurrency` group will cancel any in-flight
+            # review for this PR so the freshest diff wins.
+            gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" || \
+              echo "::warning::Could not dispatch claude-code-review.yml; review will not auto-run."
           else
-            echo "No new commits on PR head; skipping re-request."
+            echo "No new commits on PR head; skipping re-request and review dispatch."
           fi


### PR DESCRIPTION
## Summary
- GITHUB_TOKEN-driven pushes from `claude.yml` don't fire `pull_request synchronize`, and even when they do, `claude-code-review.yml`'s bot-actor filter (`!endsWith(github.actor, '[bot]')`) would skip the run — so the review workflow never ran on Claude's own edits.
- Add a `workflow_dispatch` trigger (with a `pr_number` input) to `claude-code-review.yml`, and have `claude.yml` call `gh workflow run claude-code-review.yml -f pr_number=…` whenever the recorded SHA changes during an @claude run.
- `workflow_dispatch` is one of the few events that the default `GITHUB_TOKEN` *is* allowed to fire (push is blocked to prevent recursion), so no PAT is required. The review workflow's existing `concurrency: claude-review-<pr>` group + `cancel-in-progress: true` handles overlapping dispatches.

## Test plan
- [ ] Tag `@claude` on a PR with a task that produces commits — confirm `claude-code-review.yml` fires automatically once the @claude run pushes.
- [ ] Tag `@claude` on a PR with a task that produces no commits — confirm the review workflow is *not* dispatched (SHA-before/after check still gates it).
- [ ] Confirm the dispatched review run still performs the stash → review → restore reviewer dance correctly (d-morrison ends up re-requested at the end).
- [ ] Confirm a normal human push still triggers the review via the existing `pull_request synchronize` path (the `workflow_dispatch` addition is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)