### PR TITLE
fix: resolve issues from holistic review of proportional-hazards-models chapter

### DIFF
--- a/_subfiles/proportional-hazards-models/_cor-hazard-ratio-diffloghaz.qmd
+++ b/_subfiles/proportional-hazards-models/_cor-hazard-ratio-diffloghaz.qmd
@@ -1,6 +1,6 @@
 :::{#cor-hazard-ratio-diffloghaz}
 
-#### Hazard ratio vs difference of log-odds
+#### Hazard ratio vs difference of log-hazards
 
 $$\theta(t| \vx : \vxs) = \expf{\diffloghaz(t|\vx: \vxs)}$$
 

--- a/_subfiles/proportional-hazards-models/_def-ph-model.qmd
+++ b/_subfiles/proportional-hazards-models/_def-ph-model.qmd
@@ -13,15 +13,15 @@ or semi-parametric approaches.
 
 :::{#def-ph-model}
 
-#### Proportional hazards model
+#### Cox proportional hazards model
 
-A **proportional hazards** model for a time-to-event outcome $T$ is a model where the difference in log-hazard from the baseline log-hazard is equal to a linear combination of the predictors:
+The **Cox proportional hazards** model [@cox1972regression] for a time-to-event outcome $T$ is a model where the difference in log-hazard from the baseline log-hazard is equal to a linear combination of the predictors:
 
 $$\diffloghaz(t|\vx) = \reglincomb$${#eq-ph-diffloghaz}
 
 :::
 
----
+{{< slidebreak >}}
 
 Equivalently:
 

--- a/_subfiles/proportional-hazards-models/_sec-exm-coxph-bmt.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-exm-coxph-bmt.qmd
@@ -13,12 +13,12 @@ The table provides hypothesis tests comparing groups 2 and 3 to group 1.
 Group 3 has the highest hazard, so the most significant comparison is
 not directly shown.
 
-The coefficient 0.3834 is on the log-hazard-ratio scale, as in
-log-risk-ratio. The next column gives the hazard ratio 1.4673, and a
-hypothesis (Wald) test.
+The coefficient `r round(coef(bmt.cox)["groupHigh Risk AML"], 4)` is on the log-hazard-ratio scale. The next column gives the hazard ratio `r round(exp(coef(bmt.cox)["groupHigh Risk AML"]), 4)`, and a hypothesis (Wald) test.
 
-The (not shown) group 3 vs. group 2 log hazard ratio is 0.3834 + 0.5742
-= 0.9576. The hazard ratio is then exp(0.9576) or 2.605.
+The (not shown) group 3 vs. group 2 log hazard ratio is
+`r round(coef(bmt.cox)["groupHigh Risk AML"], 4)` − (`r round(coef(bmt.cox)["groupLow Risk AML"], 4)`) =
+`r round(coef(bmt.cox)["groupHigh Risk AML"] - coef(bmt.cox)["groupLow Risk AML"], 4)`.
+The hazard ratio is `r round(exp(coef(bmt.cox)["groupHigh Risk AML"] - coef(bmt.cox)["groupLow Risk AML"]), 3)`.
 
 Inference on all coefficients and combinations can be constructed using
 `coef(bmt.cox)` and `vcov(bmt.cox)` as with logistic and poisson
@@ -47,9 +47,9 @@ by the Wald test.
 
 We can take a look at the resulting group-specific curves:
 
+:::{#fig-surv-bmt-km-cph}
 ```{r}
-#| label: fig-surv-bmt-km-cph
-#| fig-cap: "Survival Functions for Three Groups by KM and Cox Model"
+#| code-fold: true
 
 km_fit = survfit(Surv(t2, d3) ~ group, data = as.data.frame(bmt))
 
@@ -76,9 +76,12 @@ list(KM = km_fit, Cox = cox_fit) |>
   suppressWarnings() # ggsurvplot() throws some warnings that aren't too worrying
 ```
 
+Survival Functions for Three Groups by KM and Cox Model
+:::
+
 When we use `survfit()` with a Cox model, we have to specify the covariate levels we are interested in; the argument `newdata` should include a `data.frame` with the same named columns as the predictors in the Cox model and one or more levels of each.
 
----
+{{< slidebreak >}}
 
 From `?survfit.coxph`:
 

--- a/_subfiles/proportional-hazards-models/_sec-surv-conditional-hazards.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-surv-conditional-hazards.qmd
@@ -12,7 +12,7 @@ given $T \ge t$ and $\vX = \vx$:
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#def-base-hazard}
 
@@ -37,7 +37,7 @@ the intercept term in linear regression,
 but it is **not** a mean.
 :::
 
----
+{{< slidebreak >}}
 
 ::: notes
 Similarly:
@@ -45,7 +45,7 @@ Similarly:
 
 {{< include _subfiles/proportional-hazards-models/_def-base-cuhaz.qmd >}}
 
----
+{{< slidebreak >}}
 
 ::: notes
 Also:
@@ -62,7 +62,7 @@ are all equal to their default values.
 $$\surv_0(t) \eqdef \surv(t | \vX = \vzero)$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: notes
 Now, let's define ***how*** the hazard function depends on covariates.
@@ -76,61 +76,61 @@ that is:
 
 {{< include _subfiles/proportional-hazards-models/_def-loghaz.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_def_cond-loghaz.qmd >}}
 
-::: note
+::: notes
 In contrast with Poisson regression,
 here $\loghaz(t|\vx)$ depends on **both** $t$ **and** $\vx$.
 :::
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_def-base-loghaz.qmd >}}
 
----
+{{< slidebreak >}}
 
 :::{#thm-haz-from-loghaz}
 $$
-\begin{aligned}
-\haz(t|\vx) &= \exp{\loghaz(t|\vx)}
+\ba
+\haz(t|\vx) &= \expf{\loghaz(t|\vx)}
 \ea
 $$
 :::
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_def-diffloghaz.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_thm-diff-loghaz.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_cor-hazard-ratio-diffloghaz.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_def-difflog-hazard-from-baseline.qmd >}}
 
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_thm-loghaz-decomp.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_def-hr-vs-baseline.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_cor-hazard-ratio-vs-baseline.qmd >}}
 
----
+{{< slidebreak >}}
 
-:::{#cor-difflogodds-log-HR}
+:::{#cor-diffloghaz-log-HR}
 
 $$\diffloghaz(t|\vx) = \logf{\theta(t| \vx)}$$
 

--- a/_subfiles/proportional-hazards-models/_sec-test-ph-assumption.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-test-ph-assumption.qmd
@@ -40,9 +40,9 @@ bmt_curves =
     cumhaz3 = -log(sf3(timevec)))
 ```
 
+:::{#fig-HR-bmt}
 ```{r}
-#| fig-cap: "Hazard Ratios by Disease Group for `bmt` data"
-#| label: fig-HR-bmt
+#| code-fold: true
 library(ggplot2)
 bmt_rel_hazard_plot =
   bmt_curves |>
@@ -64,23 +64,29 @@ bmt_rel_hazard_plot =
 print(bmt_rel_hazard_plot)
 ```
 
----
+Hazard Ratios by Disease Group for `bmt` data
+:::
+
+{{< slidebreak >}}
 
 We can zoom in on the first 300 days to take a closer look:
 
+:::{#fig-HR-bmt-inset}
 ```{r}
-#| fig-cap: "Hazard Ratios by Disease Group (0-300 Days)"
-#| label: fig-HR-bmt-inset
+#| code-fold: true
 bmt_rel_hazard_plot + xlim(c(0,300))
 ```
 
----
+Hazard Ratios by Disease Group (0-300 Days)
+:::
+
+{{< slidebreak >}}
 
 The cumulative hazard curves should also be proportional
 
+:::{#fig-cuhaz-bmt}
 ```{r}
-#| fig-cap: "Disease-Free Cumulative Hazard by Disease Group"
-#| label: fig-cuhaz-bmt
+#| code-fold: true
 library(ggfortify)
 plot_cuhaz_bmt =
   bmt |>
@@ -93,15 +99,21 @@ plot_cuhaz_bmt |> print()
 
 ```
 
----
+Disease-Free Cumulative Hazard by Disease Group
+:::
 
+{{< slidebreak >}}
+
+:::{#fig-cuhaz-bmt-loglog}
 ```{r}
-#| fig-cap: "Disease-Free Cumulative Hazard by Disease Group (log-scale)"
-#| label: fig-cuhaz-bmt-loglog
+#| code-fold: true
 plot_cuhaz_bmt +
   scale_y_log10() +
   scale_x_log10()
 ```
+
+Disease-Free Cumulative Hazard by Disease Group (log-scale)
+:::
 
 ### Smoothed hazard functions
 
@@ -117,9 +129,9 @@ decreasing, constant, etc. Are the hazards "proportional"?
 :::
 
 
+:::{#fig-smoothed-hazard-bmt}
 ```{r}
-#| fig-cap: "Smoothed Hazard Rate Estimates by Disease Group"
-#| label: fig-smoothed-hazard-bmt
+#| code-fold: true
 library(muhaz)
 
 muhaz(bmt$t2,bmt$d3,bmt$group=="High Risk AML") |> plot(lwd=2,col=3)
@@ -127,6 +139,9 @@ muhaz(bmt$t2,bmt$d3,bmt$group=="ALL") |> lines(lwd=2,col=1)
 muhaz(bmt$t2,bmt$d3,bmt$group=="Low Risk AML") |> lines(lwd=2,col=2)
 legend("topright",c("ALL","Low Risk AML","High Risk AML"),col=1:3,lwd=2)
 ```
+
+Smoothed Hazard Rate Estimates by Disease Group
+:::
 
 ::: notes
 Group 3 was plotted first because it has the highest hazard.

--- a/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
@@ -2,7 +2,7 @@
 
 <!-- {{< include _subfiles/misc/_sec_cox-bio.qmd >}} -->
 
----
+{{< slidebreak >}}
 
 ::: notes
 Let's make two generalizations. 
@@ -13,11 +13,11 @@ we will indicate this dependence by extending our notation for hazard:
 
 {{< include _subfiles/proportional-hazards-models/_sec-surv-conditional-hazards.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/proportional-hazards-models/_def-ph-model.qmd >}}
 
----
+{{< slidebreak >}}
 
 
 :::{#lem-diffloghaz-ph}
@@ -33,7 +33,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-hazard-ratio-ph}
 
@@ -54,13 +54,13 @@ So for proportional hazards models, we can write the hazard ratio using a shorth
 
 $$\theta(t| \vx : \vxs)  = \theta(\vx : \vxs)$$
 
----
+{{< slidebreak >}}
 
 :::{#lem-ph-diffloghaz-0}
 $$\diffloghaz(t|\vx)= \reglincomb$${#eq-diffloghaz-0-ph}
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-hazard-ratio-vs-baseline-ph}
 
@@ -70,7 +70,7 @@ $$\theta(t|\vx) = \expf{\reglincomb}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -87,30 +87,30 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-ph-haz-decomp}
-$$\haz(t|x) = \haz_0(t)\theta(x)$$
+$$\haz(t|\vx) = \haz_0(t)\theta(\vx)$$
 :::
 
----
+{{< slidebreak >}}
 
 Also:
 
 :::{#thm-ph-also}
 
 $$
-\begin{aligned}
-\theta(x) &= \exp{\diffloghaz(x)}
+\ba
+\theta(\vx) &= \expf{\diffloghaz(\vx)}
 \\
-\log{\haz(t|x)} 
-&= \log{\haz_0(t)} + \diffloghaz(x)
+\logf{\haz(t|\vx)}
+&= \logf{\haz_0(t)} + \diffloghaz(\vx)
 \\
-&= \loghaz_0(t) + \diffloghaz(x)
+&= \loghaz_0(t) + \diffloghaz(\vx)
 \\
-\diffloghaz(x) &= \reglincomb \\
+\diffloghaz(\vx) &= \reglincomb \\
 &\eqdef \beta_1x_1+\cdots+\beta_px_p
-\end{aligned}
+\ea
 $$
 
 :::
@@ -124,27 +124,27 @@ because it is absorbed in the base hazard.
 
 :::
 
----
+{{< slidebreak >}}
 
-Alternatively, we could define $\beta_0(t) = \log{\haz_0(t)}$, and then:
+Alternatively, we could define $\beta_0(t) = \logf{\haz_0(t)}$, and then:
 
 $$\eta(x,t) = \beta_0(t) + \beta_1x_1+\cdots+\beta_px_p$$
 
----
+{{< slidebreak >}}
 
 ::: notes
-For two different individuals 
-with covariate patterns $\vec x_1$ and $\vec x_2$, 
-the ratio of the hazard functions 
+For two different individuals
+with covariate patterns $\vx_1$ and $\vx_2$,
+the ratio of the hazard functions
 (a.k.a. **hazard ratio**, a.k.a. **relative hazard**) is:
 :::
 
 $$
-\begin{aligned}
-\frac{\haz(t|\vec x_1)}{\haz(t|\vec x_2)}
-&=\frac{\haz_0(t)\theta(\vec x_1)}{\haz_0(t)\theta(\vec x_2)}\\
-&=\frac{\theta(\vec x_1)}{\theta(\vec x_2)}\\
-\end{aligned}
+\ba
+\frac{\haz(t|\vx_1)}{\haz(t|\vx_2)}
+&=\frac{\haz_0(t)\theta(\vx_1)}{\haz_0(t)\theta(\vx_2)}\\
+&=\frac{\theta(\vx_1)}{\theta(\vx_2)}\\
+\ea
 $$
 
 ::: notes
@@ -154,102 +154,102 @@ This property is a structural limitation of the model;
 it is called the **proportional hazards assumption**.
 :::
 
----
+{{< slidebreak >}}
 
 ::: {#def-pha}
 ### proportional hazards
 
 A conditional probability distribution $p(T|X)$
-has **proportional hazards** if the hazard ratio $\haz(t|\vec x_1)/\haz(t|\vec x_2)$ does not depend on $t$. Mathematically, it can be written as:
+has **proportional hazards** if the hazard ratio $\haz(t|\vx_1)/\haz(t|\vx_2)$ does not depend on $t$. Mathematically, it can be written as:
 
 $$
-\frac{\haz(t|\vec x_1)}{\haz(t|\vec x_2)}
-= \theta(\vec x_1,\vec x_2)
+\frac{\haz(t|\vx_1)}{\haz(t|\vx_2)}
+= \theta(\vx_1,\vx_2)
 $$
 
 :::
 
 ::: notes
-As we saw above, Cox's proportional hazards model has this property, with $\theta(\vec x_1,\vec x_2) = \frac{\theta(\vec x_1)}{\theta(\vec x_2)}$.
+As we saw above, Cox's proportional hazards model has this property, with $\theta(\vx_1,\vx_2) = \frac{\theta(\vx_1)}{\theta(\vx_2)}$.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-haz-ratio-notations}
 
 ::: notes
-We are using two similar notations, 
-$\theta(\vx,\vxs)$ and $\theta(\vec x)$. 
-We can link these notations: 
-$$\theta(\vx) \eqdef \theta(\vx, \vec 0)$$
+We are using two similar notations,
+$\theta(\vx,\vxs)$ and $\theta(\vx)$.
+We can link these notations:
+$$\theta(\vx) \eqdef \theta(\vx, \vzero)$$
 
 Then:
 :::
 
 $$\theta(\vx, \vxs) = \frac{\theta(\vx)}{\theta(\vxs)}$$
-$$\theta(\vec 0) = \theta(\vec 0, \vec 0) = 1$$
+$$\theta(\vzero) = \theta(\vzero, \vzero) = 1$$
 
 :::
 
----
+{{< slidebreak >}}
 
 The proportional hazards model also has additional notable properties:
 
 $$
-\begin{aligned}
-\frac{\haz(t|\vec x_1)}{\haz(t|\vec x_2)}
-&=\frac{\theta(\vec x_1)}{\theta(\vec x_2)}\\
-&=\frac{\exp{\eta(\vec x_1)}}{\exp{\eta(\vec x_2)}}\\
-&=\exp{\eta(\vec x_1)-\eta(\vec x_2)}\\
-&=\exp{\vec x_1'\beta-\vec x_2'\beta}\\
-&=\exp{(\vec x_1 - \vec x_2)'\beta}\\
-\end{aligned}
+\ba
+\frac{\haz(t|\vx_1)}{\haz(t|\vx_2)}
+&=\frac{\theta(\vx_1)}{\theta(\vx_2)}\\
+&=\frac{\expf{\eta(\vx_1)}}{\expf{\eta(\vx_2)}}\\
+&=\expf{\eta(\vx_1)-\eta(\vx_2)}\\
+&=\expf{\vx_1'\vb-\vx_2'\vb}\\
+&=\expf{(\vx_1 - \vx_2)'\vb}\\
+\ea
 $$
 
----
+{{< slidebreak >}}
 
 Hence on the log scale, we have:
 
 :::{#thm-diff-loghaz-lincom}
 $$
 \ba
-\log{\frac{\haz(t|\vx)}{\haz(t|\vxs)}}
-&= \diffloghaz(t|\vx : \vxs) 
+\logf{\frac{\haz(t|\vx)}{\haz(t|\vxs)}}
+&= \diffloghaz(t|\vx : \vxs)
 \\
 &\eqdef \loghaz(t|\vx) - \loghaz(t|\vxs)
 \\
-&=\eta(\vec x_1)-\eta(\vec x_2)\\
-&= \vec x_1'\beta-\vec x_2'\beta\\
-&= (\vec x_1 - \vec x_2)'\beta
-\end{aligned}
+&=\eta(\vx)-\eta(\vxs)\\
+&= \vx'\vb-\vxs'\vb\\
+&= (\vx - \vxs)'\vb
+\ea
 $$
 :::
 
----
+{{< slidebreak >}}
 
 If only one covariate $x_j$ is changing, then:
 
 $$
-\begin{aligned}
-\log{\frac{\haz(t|\vec x_1)}{\haz(t|\vec x_2)}}
+\ba
+\logf{\frac{\haz(t|\vx_1)}{\haz(t|\vx_2)}}
 &=  (x_{1j} - x_{2j}) \cdot \beta_j\\
 &\propto (x_{1j} - x_{2j})
-\end{aligned}
+\ea
 $$
 
 ::: notes
-That is, under Cox's model $\haz(t|\vec x) = \haz_0(t)\exp{\vec x'\beta}$, the log of the hazard ratio is proportional to the difference in $x_j$, with the proportionality coefficient equal to $\beta_j$.
+That is, under Cox's model $\haz(t|\vx) = \haz_0(t)\expf{\vx'\vb}$, the log of the hazard ratio is proportional to the difference in $x_j$, with the proportionality coefficient equal to $\beta_j$.
 :::
 
----
+{{< slidebreak >}}
 
 Further,
 
 $$
-\begin{aligned}
-\log{\haz(t|\vec x)}
-&=\log{\haz_0(t)}  + x'\beta
-\end{aligned}
+\ba
+\logf{\haz(t|\vx)}
+&=\logf{\haz_0(t)}  + \reglincomb
+\ea
 $$
 
 ::: notes
@@ -263,27 +263,27 @@ See also:
 
 ### Additional properties of the proportional hazards model
 
-If $\haz(t|x)= \haz_0(t)\theta(x)$, then:
+If $\haz(t|\vx)= \haz_0(t)\theta(\vx)$, then:
 
 :::{#thm-ph-cuhaz}
 
 #### Cumulative hazards are also proportional to $\cuhaz_0(t)$
 
 $$
-\begin{aligned}
-\cuhaz(t|x)
+\ba
+\cuhaz(t|\vx)
 &\eqdef \int_{u=0}^t \haz(u)du\\
-&= \int_{u=0}^t \haz_0(u)\theta(x)du\\
-&= \theta(x)\int_{u=0}^t \haz_0(u)du\\
-&= \theta(x)\cuhaz_0(t)
-\end{aligned}
+&= \int_{u=0}^t \haz_0(u)\theta(\vx)du\\
+&= \theta(\vx)\int_{u=0}^t \haz_0(u)du\\
+&= \theta(\vx)\cuhaz_0(t)
+\ea
 $$
 
-where $\cuhaz_0(t) \eqdef \cuhaz(t|0) = \int_{u=0}^t \haz_0(u)du$.
+where $\cuhaz_0(t) \eqdef \cuhaz(t|\vzero) = \int_{u=0}^t \haz_0(u)du$.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-log-cuhaz-parallel}
 
@@ -294,7 +294,7 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-log-nlog-surv}
 ### linear model for log-negative-log survival
@@ -305,26 +305,26 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-ph-surv}
 #### Survival functions are exponential multiples of $\surv_0(t)$
 
-$$\surv(t|x) = \sb{\surv_0(t)}^{\theta(x)}$$
+$$\surv(t|\vx) = \sb{\surv_0(t)}^{\theta(\vx)}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 $$
-\begin{aligned}
-\surv(t|x)
-&= \expf{-\cuhaz(t|x)}\\
-&= \expf{-\theta(x)\cdot \cuhaz_0(t)}\\
-&= \paren{\expf{- \cuhaz_0(t)}}^{\theta(x)}\\
-&= \sb{\surv_0(t)}^{\theta(x)}\\
-\end{aligned}
+\ba
+\surv(t|\vx)
+&= \expf{-\cuhaz(t|\vx)}\\
+&= \expf{-\theta(\vx)\cdot \cuhaz_0(t)}\\
+&= \paren{\expf{- \cuhaz_0(t)}}^{\theta(\vx)}\\
+&= \sb{\surv_0(t)}^{\theta(\vx)}\\
+\ea
 $$
 
 :::

--- a/_subfiles/proportional-hazards-models/_sec_coxph-adjust_ties.qmd
+++ b/_subfiles/proportional-hazards-models/_sec_coxph-adjust_ties.qmd
@@ -1,5 +1,5 @@
 
----
+{{< slidebreak >}}
 
 At each time $t_i$ at which more than one of the subjects has an event,
 let $d_i$ be the number of events at that time, $D_i$ the set of
@@ -7,19 +7,17 @@ subjects with events at that time, and let $s_i$ be a covariate vector
 for an artificial subject obtained by adding up the covariate values for
 the subjects with an event at time $t_i$. Let
 $$\bar\eta_i = \beta_1s_{i1}+\cdots+\beta_ps_{ip}$$ and
-$\bar\theta_i = \exp{\bar\eta_i}$.
+$\bar\theta_i = \expf{\bar\eta_i}$.
 
-Let $s_i$ be a covariate vector for an artificial subject obtained by
-adding up the covariate values for the subjects with an event at time
-$t_i$. Note that
+Note that
 
 $$
-\begin{aligned}
+\ba
 \bar\eta_i &=\sum_{j \in D_i}\beta_1x_{j1}+\cdots+\beta_px_{jp}\\
 &= \beta_1s_{i1}+\cdots+\beta_ps_{ip}\\
-\bar\theta_i &= \exp{\bar\eta_i}\\
+\bar\theta_i &= \expf{\bar\eta_i}\\
 &= \prod_{j \in D_i}\theta_i
-\end{aligned}
+\ea
 $$
 
 #### Breslow's method for ties
@@ -27,11 +25,11 @@ $$
 Breslow's method estimates the partial likelihood as
 
 $$
-\begin{aligned}
+\ba
 L(\beta|T) &=
 \prod_i \frac{\bar\theta_i}{[\sum_{k \in R(t_i)} \theta_k]^{d_i}}\\
 &= \prod_i \prod_{j \in D_i}\frac{\theta_j}{\sum_{k \in R(t_i)} \theta_k}
-\end{aligned}
+\ea
 $$
 
 This method is equivalent to treating each event as distinct and using the non-ties formula.

--- a/_subfiles/proportional-hazards-models/_sec_fit-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec_fit-coxph.qmd
@@ -1,6 +1,6 @@
 {{< include latex-macros/macros.qmd >}}
 
----
+{{< slidebreak >}}
 
 ::: notes
 How do we fit a proportional hazards regression model? We need to
@@ -12,14 +12,14 @@ and
 :::
 
 $$
-\begin{aligned}
-\eta(\vec{x}) &= \beta_1x_{1}+\cdots+\beta_p x_{p}\\
-\theta(\vec{x}) &= e^{\eta(\vec{x})}\\
-\haz(t|X=x)&= \haz_0(t)e^{\eta(\vec{x})}=\theta(\vec{x}) \haz_0(t)
-\end{aligned}
+\ba
+\eta(\vx) &= \beta_1x_{1}+\cdots+\beta_p x_{p}\\
+\theta(\vx) &= \expf{\eta(\vx)}\\
+\haz(t|\vx)&= \haz_0(t)\expf{\eta(\vx)}=\theta(\vx) \haz_0(t)
+\ea
 $$
 
----
+{{< slidebreak >}}
 
 ::: notes
 Conditional on a single failure at time $t$, the probability that the
@@ -27,11 +27,11 @@ event is due to subject $f\in R(t)$ is approximately
 :::
 
 $$
-\begin{aligned}
+\ba
 \Pr(f \text{ fails}|\text{1 failure at } t)
-&= \frac{\haz_0(t)e^{\eta(\vec{x}_f)}}{\sum_{k \in R(t)}\haz_0(t)e^{\eta(\vec{x}_f)}}\\
-&=\frac{\theta(\vec{x}_f)}{\sum_{k \in R(t)} \theta(\vec{x}_k)}
-\end{aligned}
+&= \frac{\haz_0(t)\expf{\eta(\vx_f)}}{\sum_{k \in R(t)}\haz_0(t)\expf{\eta(\vx_k)}}\\
+&=\frac{\theta(\vx_f)}{\sum_{k \in R(t)} \theta(\vx_k)}
+\ea
 $$
 
 ::: notes
@@ -51,7 +51,7 @@ $$
 \sum_{k\in R(t)}p_k\left[\prod_{m\in R(t), m\ne k} (1-p_m)\right]\approx\sum_{k\in R(t)}p_k
 $$
 
----
+{{< slidebreak >}}
 
 ::: notes
 If subject $i$ is the one who experiences the event of interest at time

--- a/_subfiles/proportional-hazards-models/_thm-diff-loghaz.qmd
+++ b/_subfiles/proportional-hazards-models/_thm-diff-loghaz.qmd
@@ -9,7 +9,7 @@ then:
 $$\diffloghaz(t|\vx : \vxs)= \logf{\theta(t| \vx : \vxs)}$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 

--- a/chapters/coxph-model-building.qmd
+++ b/chapters/coxph-model-building.qmd
@@ -167,7 +167,7 @@ km_and_cph <-
 ```
 
 ```{r}
-#| fig-cap: "Observed and expected survival curves for `bmt` data"
+#| fig-cap: "Observed and expected survival curves for `hodg2` data"
 km_and_cph |>
   ggplot(aes(x = time, y = surv, col = model)) +
   geom_step() +
@@ -805,7 +805,7 @@ $$
 
 Roughly centered on 0 with approximate standard deviation 1.
 
-### 
+### Computing residuals
 
 ```{r}
 hodg_mart <- residuals(hodg_cox2, type = "martingale")
@@ -925,7 +925,7 @@ The two largest values are observations 1 and 16. The smallest value is observat
 The most important observations to examine seem to be 1, 15, 16, 18, and
 29.
 
-### 
+### Examining influential observations
 
 ```{r}
 with(hodg, summary(time[delta == 1]))
@@ -975,6 +975,7 @@ hodg2[c(1, 15, 16, 18, 29), ] |>
 
 ```{r}
 #| tbl-cap: "Linear Risk Predictors for Lymphoma"
+library(pander)
 hodg_cox2 |>
   predict(
     reference = "zero",
@@ -1718,7 +1719,7 @@ bladder_cox3 <- bladder_cox2 |> update(. ~ . - size)
 summary(bladder_cox3)
 ```
 
-::: hidden
+::: {.content-hidden}
 Ways to check PH assumption:
 
 -   cloglog

--- a/references.bib
+++ b/references.bib
@@ -286,6 +286,17 @@ eprint = {https://www.aerzteblatt.de/pdf.asp?id=222631}
   publisher={Oxford University Press}
 }
 
+@article{cox1972regression,
+  title={Regression models and life-tables},
+  author={Cox, David R},
+  journal={Journal of the Royal Statistical Society: Series B (Methodological)},
+  volume={34},
+  number={2},
+  pages={187--202},
+  year={1972},
+  publisher={Wiley}
+}
+
 @article{canchola2003cox,
   title={Cox regression using different time-scales},
   author={Canchola, Alison J and Stewart, Susan L and Bernstein, Leslie and West, Dee W and Ross, Ronald K and Deapen, Dennis and Pinder, Richard and Reynolds, Peggy and Wright, William and Anton-Culver, Hoda and others},


### PR DESCRIPTION
Fixes identified in #757 from the holistic review of the proportional hazards models chapter.

**Changes across 11 files:**
- Fix "log-odds" → "log-hazards" in `_cor-hazard-ratio-diffloghaz.qmd`
- Replace all `---` slide separators with `{{< slidebreak >}}` in subfiles
- Convert figure chunks from `#| fig-cap:` to `:::{#fig-...}` div format
- Fix `::: note` typo → `::: notes`
- Fix empty `###` headers in `coxph-model-building.qmd`
- Fix wrong dataset name in figure caption (bmt → hodg2)
- Remove duplicated sentence in `_sec_coxph-adjust_ties.qmd`
- Fix `::: hidden` → `::: {.content-hidden}`
- Add `library(pander)` before usage
- Replace `\begin{aligned}...\end{aligned}` with `\ba...\ea` macros
- Fix scalar `x` → `\vx` and `\vec{x}` → `\vx` notation
- Fix `\log{...}` → `\logf{...}` and `\exp{...}` → `\expf{...}`
- Add Cox (1972) citation to bibliography and model definition
- Fix imprecise "log-risk-ratio" in coefficient interpretation

Generated with [Claude Code](https://claude.ai/code)