### PR TITLE
make exm divs foldable (expanded by default) in html format

### DIFF
--- a/_extensions/d-morrison/callouty-theorem/callouty-theorem.lua
+++ b/_extensions/d-morrison/callouty-theorem/callouty-theorem.lua
@@ -153,7 +153,13 @@ local function calloutify(el, is_proof)
   if override_title then
     callout_tbl.title = spawn_callout_title(my_types[typ].title, el.name)
   end
-  callout_tbl.content = my_Theorem(el)
+  if override_title and not is_proof then
+    -- Use raw body content to avoid duplicating the auto-generated theorem heading.
+    -- Preserve el.identifier so cross-reference links resolve to the right anchor.
+    callout_tbl.content = pandoc.Div(el.content, pandoc.Attr(el.identifier))
+  else
+    callout_tbl.content = my_Theorem(el)
+  end
   local callout = quarto.Callout(callout_tbl)
   return callout
 end

--- a/_extensions/d-morrison/callouty-theorem/callouty-theorem.lua
+++ b/_extensions/d-morrison/callouty-theorem/callouty-theorem.lua
@@ -154,9 +154,22 @@ local function calloutify(el, is_proof)
     callout_tbl.title = spawn_callout_title(my_types[typ].title, el.name)
   end
   if override_title and not is_proof then
-    -- Use raw body content to avoid duplicating the auto-generated theorem heading.
-    -- Preserve el.identifier so cross-reference links resolve to the right anchor.
-    callout_tbl.content = pandoc.Div(el.content, pandoc.Attr(el.identifier))
+    -- Use raw body content to avoid duplicating the auto-generated theorem
+    -- heading. Quarto's Theorem element wraps the original pandoc Div as
+    -- `el.div`; the body blocks live at `el.div.content`, consistent with
+    -- the `el.div.attr` access already used above. `el.content` itself is
+    -- nil on the custom Theorem AST node.
+    --
+    -- We pass the blocks directly rather than re-wrapping in another
+    -- pandoc.Div with the identifier — a nested Div with its own id
+    -- triggered an internal error in Quarto's jog.lua walker. Instead we
+    -- prepend a Span carrying `el.identifier` so cross-references like
+    -- `@exm-foo` still resolve to a real anchor inside the callout body.
+    local body = (el.div and el.div.content) or pandoc.Blocks({})
+    if el.identifier and el.identifier ~= "" then
+      body:insert(1, pandoc.Plain({pandoc.Span({}, pandoc.Attr(el.identifier))}))
+    end
+    callout_tbl.content = body
   else
     callout_tbl.content = my_Theorem(el)
   end

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -162,7 +162,9 @@ callouty-theorem:
     override-title: false
     callout:
       type: exm
-      appearance: minimal
+      appearance: default
+      collapse: false
+      icon: false
   exr:
     override-title: false
     callout:

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -159,7 +159,7 @@ callouty-theorem:
       type: def
       appearance: minimal
   exm:
-    override-title: false
+    override-title: true
     callout:
       type: exm
       appearance: default


### PR DESCRIPTION
Make `{#exm-...}` example divs foldable (collapsible but expanded by default) in HTML format, by updating the `callouty-theorem` callout config for `exm` in `_quarto-website.yml`.

Also flips `override-title: false` → `true` for the `exm` block, so the example name (e.g. "Polynomial expansions") appears in the title bar instead of being rendered as a duplicate inner heading below the title.

Closes #761.

## Implementation notes

- `_quarto-website.yml`: switches `exm` to `appearance: default` + `collapse: false` + `icon: false` + `override-title: true` — consistent with the existing pattern (`remark` uses `collapse: false` too; `proof`/`solution` use `collapse: true`).
- `callouty-theorem.lua`: when `override-title and not is_proof`, builds the callout body from `el.div.content` (Quarto's custom Theorem AST exposes the original pandoc Div at `el.div`, not directly at `el`), prepending a `pandoc.Span` anchor for the `#exm-...` cross-reference identifier. Using a Span rather than a nested Div avoids tripping Quarto's `jog.lua` traversal on duplicate-`id` Divs.

Generated with [Claude Code](https://claude.ai/code)
