### PR TITLE
claude.yml: serialize sessions per PR; poll for new @claude comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -314,8 +314,10 @@ jobs:
             3. If any matching entries exist, address each one in this
                same session (in chronological order), then repeat from
                step 1. Stop when no new @claude requests remain, or
-               after **at most 5 polling rounds total** — whichever
-               comes first. The cap prevents a pathological ping-pong
+               after **at most 5 additional iterations of steps 1–3**
+               (i.e. the cap applies to the polling loop, not to the
+               initial task you were triggered for) — whichever comes
+               first. The cap prevents a pathological ping-pong
                between a user (or two bots) and this session from
                keeping the run alive indefinitely; if you hit the cap
                with new comments still arriving, post a comment saying

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -221,8 +221,8 @@ jobs:
 
             This run was triggered by a `${{ github.event_name }}`
             event; the `/pulls/...` endpoints below only apply when the
-            triggering event was on a PR — i.e. when `github.event_name`
-            is **not** `issues`. Skip those two endpoints for `issues`
+            triggering event was on a PR — i.e. when the event type is
+            **not** `issues`. Skip those two endpoints for `issues`
             triggers (the issue body itself doesn't admit late-arriving
             `@claude` content, so there's typically nothing to poll
             anyway).
@@ -274,9 +274,13 @@ jobs:
                so and exit, and the next workflow run will pick up
                from there via the serialize-per-PR concurrency group.
 
-            4. Push all commits before finishing. The concurrency group
-               guarantees no parallel session is racing yours, so
-               git-push.sh should succeed unless someone pushed by hand.
+            4. Commit all changes before finishing — the
+               `claude-code-action` runs `git-push.sh` after your
+               session ends, so you don't (and can't, given the
+               `--allowed-tools` list) push directly. The concurrency
+               group guarantees no parallel session is racing yours,
+               so that push should succeed unless someone pushed by
+               hand.
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -154,13 +154,12 @@ jobs:
             | sort -u \
             | sed 's#.*#WebFetch(domain:&)#' \
             | paste -sd, -)
-          # `Bash(gh api:*)`, `Bash(gh pr view:*)`, `Bash(gh issue view:*)`
-          # are needed by the polling-for-new-comments prompt below: the
-          # session checks for late-arriving @claude comments before
-          # declaring done, so multi-comment bursts get handled in a
-          # single session instead of racing parallel runs.
+          # `Bash(gh api:*)` is needed by the polling-for-new-comments
+          # prompt below: the session checks for late-arriving @claude
+          # comments before declaring done, so multi-comment bursts get
+          # handled in a single session instead of racing parallel runs.
           #
-          # `Bash(gh api:*)` is intentionally broad: the polling step
+          # The permission is intentionally broad. The polling step
           # only needs GET on a few endpoints, but Claude often uses
           # `gh api` for other read-only inspection during a session
           # (e.g. fetching file SHAs, reading raw PR metadata). The
@@ -169,8 +168,11 @@ jobs:
           # so we accept the broader surface. The ultimate bound on
           # what's possible is still `GITHUB_TOKEN`'s scopes
           # (`contents: write`, `pull-requests: write`, `issues: write`),
-          # not this allowlist.
-          GH_TOOLS='Bash(gh api:*),Bash(gh pr view:*),Bash(gh issue view:*)'
+          # not this allowlist. `Bash(gh pr view:*)` and
+          # `Bash(gh issue view:*)` are strict subsets of
+          # `Bash(gh api:*)` (the CLI commands hit the same API
+          # internally), so they're omitted.
+          GH_TOOLS='Bash(gh api:*)'
           if [ -n "$WEBFETCH" ]; then
             echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
           else
@@ -217,7 +219,6 @@ jobs:
               `body` field here is where `@claude` lives for a
               `pull_request_review` trigger.
 
-            Treat N = `${{ github.event.issue.number || github.event.pull_request.number }}`.
             This run was triggered by a `${{ github.event_name }}`
             event; the `/pulls/...` endpoints below only apply when the
             triggering event was on a PR — i.e. when `github.event_name`
@@ -227,18 +228,25 @@ jobs:
             anyway).
 
             1. Fetch each endpoint (skip the `/pulls/...` ones for
-               `issues` triggers):
+               `issues` triggers — the GitHub-Actions expression
+               `${{ github.event.issue.number || github.event.pull_request.number }}`
+               is already substituted in below):
                ```
-               gh api 'repos/${{ github.repository }}/issues/N/comments' --paginate
-               gh api 'repos/${{ github.repository }}/pulls/N/comments' --paginate   # PRs only
-               gh api 'repos/${{ github.repository }}/pulls/N/reviews'  --paginate   # PRs only
+               gh api 'repos/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}/comments' --paginate
+               gh api 'repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/comments' --paginate   # PRs only
+               gh api 'repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/reviews'  --paginate   # PRs only
                ```
 
             2. From the combined response, identify entries where ALL of:
                - the relevant timestamp (`created_at` for comments,
                  `submitted_at` for reviews) is strictly greater than
-                 the triggering event's timestamp
-                 (`${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}`)
+                 the triggering event's timestamp. The fallback chain
+                 prefers exact creation/submission timestamps and only
+                 falls back to `issue.updated_at` for `issues` events
+                 with type `assigned` (the only trigger where
+                 `created_at` is not the right signal, since the issue
+                 itself wasn't created by this event):
+                 (`${{ github.event.comment.created_at || github.event.review.submitted_at || (github.event_name == 'issues' && github.event.action == 'opened' && github.event.issue.created_at) || github.event.issue.updated_at }}`)
                - the relevant text field (`body` for comments and
                  reviews) contains `@claude`
                - `user.type` is not `"Bot"` — this generically excludes
@@ -257,7 +265,14 @@ jobs:
 
             3. If any matching entries exist, address each one in this
                same session (in chronological order), then repeat from
-               step 1. Stop when no new @claude requests remain.
+               step 1. Stop when no new @claude requests remain, or
+               after **at most 5 polling rounds total** — whichever
+               comes first. The cap prevents a pathological ping-pong
+               between a user (or two bots) and this session from
+               keeping the run alive indefinitely; if you hit the cap
+               with new comments still arriving, post a comment saying
+               so and exit, and the next workflow run will pick up
+               from there via the serialize-per-PR concurrency group.
 
             4. Push all commits before finishing. The concurrency group
                guarantees no parallel session is racing yours, so

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -322,12 +322,14 @@ jobs:
                so and exit, and the next workflow run will pick up
                from there via the serialize-per-PR concurrency group.
 
-            4. Commit all changes before finishing — the
-               `claude-code-action` runs `git-push.sh` after your
-               session ends, so you don't (and can't, given the
-               `--allowed-tools` list) push directly. The concurrency
-               group guarantees no parallel session is racing yours,
-               so that push should succeed unless someone pushed by
+            4. Commit all changes before finishing. `git add`,
+               `git commit`, and `git rm` are auto-injected into the
+               allowed-tools list by the action and are available to
+               you; `git push` is NOT — the action runs its own
+               `git-push.sh` wrapper after your session ends, which
+               is what pushes to the remote. The concurrency group
+               guarantees no parallel session is racing yours, so
+               that push should succeed unless someone pushed by
                hand.
 
           # Optional: Add claude_args to customize behavior and configuration

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,17 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Serialize @claude sessions per issue/PR. Multiple rapid @claude
+# comments used to fire concurrent runs that all tried to push to the
+# same branch; the action's git-push.sh refuses non-fast-forward
+# pushes, so the loser-on-the-race silently lost its work (see PR #706
+# 2026-05-19 18:31–18:39 window, where 2 of 4 races were blocked).
+# `cancel-in-progress: false` means each new comment QUEUES behind the
+# running session rather than starting a competing one.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.event.review.pull_request_url }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -131,10 +142,16 @@ jobs:
             | sort -u \
             | sed 's#.*#WebFetch(domain:&)#' \
             | paste -sd, -)
+          # `Bash(gh api:*)`, `Bash(gh pr view:*)`, `Bash(gh issue view:*)`
+          # are needed by the polling-for-new-comments prompt below: the
+          # session checks for late-arriving @claude comments before
+          # declaring done, so multi-comment bursts get handled in a
+          # single session instead of racing parallel runs.
+          GH_TOOLS='Bash(gh api:*),Bash(gh pr view:*),Bash(gh issue view:*)'
           if [ -n "$WEBFETCH" ]; then
-            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${WEBFETCH}" >> "$GITHUB_OUTPUT"
+            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *)" >> "$GITHUB_OUTPUT"
+            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Claude Code
@@ -147,16 +164,53 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # Pick up late-arriving @claude comments before declaring done.
+          # Background: until the workflow's `concurrency:` block was added,
+          # rapid @claude comments fired concurrent runs that raced to push
+          # to the same branch; the action's git-push.sh refuses non-
+          # fast-forward pushes, so the losers silently lost their work
+          # (PR #706 2026-05-19 18:31–18:39). The concurrency block now
+          # serializes runs, but a long-running session can still miss a
+          # comment posted while it's working. This prompt has Claude
+          # explicitly poll for newer @claude mentions and address them
+          # in the same session before finishing.
+          prompt: |
+            You were triggered by an @claude mention in
+            ${{ github.event_name }}. Address the request in that
+            comment/issue/review.
+
+            **Before declaring the task complete, check for additional
+            @claude requests that arrived after the triggering event:**
+
+            1. Fetch the latest issue/PR comments:
+               `gh api 'repos/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}/comments' --paginate`
+               (PR review comments also live at this endpoint; the
+               separate `/pulls/N/comments` endpoint is only for inline
+               review-thread replies.)
+
+            2. From the response, identify comments where ALL of:
+               - `created_at` is strictly greater than the triggering
+                 comment's timestamp
+                 (`${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}`)
+               - body contains `@claude`
+               - user.login is neither `claude[bot]` nor `github-actions[bot]`
+
+            3. If any matching comments exist, address each one in this
+               same session (in chronological order), then repeat from
+               step 1. Stop when no new @claude comments remain.
+
+            4. Push all commits before finishing. The concurrency group
+               guarantees no parallel session is racing yours, so
+               git-push.sh should succeed unless someone pushed by hand.
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # Allow the pre-commit checklist tools from CLAUDE.md (Rscript for
           # lint/spell-check, quarto render for chapter previews), curl for
-          # downloading source PDFs too large for WebFetch (issue #740), plus
-          # WebFetch for every host in the shared stats-allowlist.
+          # downloading source PDFs too large for WebFetch (issue #740), the
+          # gh CLI for the polling step in the prompt above, plus WebFetch
+          # for every host in the shared stats-allowlist.
           claude_args: '--allowed-tools "${{ steps.tools.outputs.allowed }}"'
 
       - name: Re-request review and dispatch code review if Claude pushed commits

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,12 +20,17 @@ on:
 concurrency:
   # `github.event.pull_request.number` is already populated for
   # `pull_request_review` and `pull_request_review_comment` events, so
-  # the two fallbacks below cover all four trigger types — no third
-  # clause needed. A stray `github.event.review.pull_request_url`
-  # fallback would also be wrong: it's a full API URL string, not a
-  # number, so it would produce a different group than the `claude-N`
-  # used by `issue_comment` events on the same PR.
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  # the two issue/PR-number expressions below cover all four trigger
+  # types. The `|| github.run_id` tail is a defensive fallback: if
+  # both numbers are ever undefined (shouldn't happen with the four
+  # `on:` triggers above), the group would otherwise collapse to
+  # `claude-`, serializing every session globally. Falling back to
+  # `run_id` keeps the unknown case from blocking unrelated PRs.
+  # A stray `github.event.review.pull_request_url` fallback that lived
+  # here previously was dropped: it's a full API URL string, not a
+  # number, so it would have produced a different group than the
+  # `claude-N` used by `issue_comment` events on the same PR.
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -213,9 +218,16 @@ jobs:
               `pull_request_review` trigger.
 
             Treat N = `${{ github.event.issue.number || github.event.pull_request.number }}`.
+            This run was triggered by a `${{ github.event_name }}`
+            event; the `/pulls/...` endpoints below only apply when the
+            triggering event was on a PR — i.e. when `github.event_name`
+            is **not** `issues`. Skip those two endpoints for `issues`
+            triggers (the issue body itself doesn't admit late-arriving
+            `@claude` content, so there's typically nothing to poll
+            anyway).
 
-            1. Fetch each endpoint (skip the `/pulls/...` ones if N is
-               an issue rather than a PR):
+            1. Fetch each endpoint (skip the `/pulls/...` ones for
+               `issues` triggers):
                ```
                gh api 'repos/${{ github.repository }}/issues/N/comments' --paginate
                gh api 'repos/${{ github.repository }}/pulls/N/comments' --paginate   # PRs only
@@ -229,8 +241,13 @@ jobs:
                  (`${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}`)
                - the relevant text field (`body` for comments and
                  reviews) contains `@claude`
-               - `user.login` is neither `claude[bot]` nor
-                 `github-actions[bot]`
+               - `user.type` is not `"Bot"` — this generically excludes
+                 GitHub App accounts (claude[bot], github-actions[bot],
+                 dependabot[bot], etc.) and prevents the polling loop
+                 from being driven by an arbitrary bot that learns to
+                 say `@claude`. A human who has somehow set their
+                 `user.type` to `Bot` would also be excluded, but that
+                 isn't a real scenario.
 
                Note: for `issues` events the triggering timestamp falls
                back to `issue.updated_at`, which is a coarse signal

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -165,25 +165,31 @@ jobs:
             | sort -u \
             | sed 's#.*#WebFetch(domain:&)#' \
             | paste -sd, -)
-          # `Bash(gh api:*)` is needed by the polling-for-new-comments
-          # prompt below: the session checks for late-arriving @claude
-          # comments before declaring done, so multi-comment bursts get
-          # handled in a single session instead of racing parallel runs.
+          # `Bash(gh api repos/<this-repo>/*)` is needed by the
+          # polling-for-new-comments prompt below: the session checks
+          # for late-arriving @claude comments before declaring done,
+          # so multi-comment bursts get handled in a single session
+          # instead of racing parallel runs.
           #
-          # The permission is intentionally broad. The polling step
-          # only needs GET on a few endpoints, but Claude often uses
-          # `gh api` for other read-only inspection during a session
-          # (e.g. fetching file SHAs, reading raw PR metadata). The
-          # allowed-tools pattern doesn't currently support a clean way
-          # to restrict to GET-only or to a specific endpoint path,
-          # so we accept the broader surface. The ultimate bound on
-          # what's possible is still `GITHUB_TOKEN`'s scopes
-          # (`contents: write`, `pull-requests: write`, `issues: write`),
-          # not this allowlist. `Bash(gh pr view:*)` and
-          # `Bash(gh issue view:*)` are strict subsets of
-          # `Bash(gh api:*)` (the CLI commands hit the same API
+          # The pattern is scoped to the current repository's API
+          # surface, which covers the polling step's endpoints
+          # (`repos/<repo>/issues/N/comments`, `repos/<repo>/pulls/N/comments`,
+          # `repos/<repo>/pulls/N/reviews`) and the routine read-only
+          # session uses (fetching file SHAs, reading PR metadata,
+          # checking branch contents). It excludes cross-repo and
+          # cross-org `gh api` calls (`/user`, `/orgs/...`, `/repos/OTHER/...`)
+          # that the session doesn't need.
+          #
+          # Within the repo scope the pattern still matches write
+          # endpoints (`gh api -X POST/PATCH/DELETE repos/<repo>/...`),
+          # not just reads, because allowed-tools doesn't support
+          # HTTP-method filtering. The ultimate bound on what's
+          # possible is `GITHUB_TOKEN`'s scopes (`contents: write`,
+          # `pull-requests: write`, `issues: write`), not this
+          # allowlist. `Bash(gh pr view:*)` and `Bash(gh issue view:*)`
+          # are strict subsets (the CLI commands hit the same API
           # internally), so they're omitted.
-          GH_TOOLS='Bash(gh api:*)'
+          GH_TOOLS="Bash(gh api repos/${{ github.repository }}/:*)"
           if [ -n "$WEBFETCH" ]; then
             echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
           else
@@ -210,6 +216,19 @@ jobs:
           # comment posted while it's working. This prompt has Claude
           # explicitly poll for newer @claude mentions and address them
           # in the same session before finishing.
+          #
+          # claude-code-action behaviour note: when `prompt:` is set, the
+          # action APPENDS it (wrapped in `<custom_instructions>`) to the
+          # default tag-mode prompt — it does NOT replace the default.
+          # The default prompt already provides the triggering content via
+          # `<trigger_comment>` (or `<pr_or_issue_body>` for `issues`
+          # events) plus the formatted PR/issue body, comments, review
+          # comments, and changed files. The instructions below therefore
+          # only need to describe the polling behaviour; the request
+          # itself is already visible to Claude.
+          # (verified against
+          #  https://github.com/anthropics/claude-code-action/blob/main/src/create-prompt/index.ts —
+          #  see `generatePrompt`'s `if (context.githubContext?.inputs?.prompt)` branch.)
           prompt: |
             You were triggered by an @claude mention in
             ${{ github.event_name }}. Address the request in that
@@ -258,12 +277,19 @@ jobs:
                - the relevant timestamp (`created_at` for comments,
                  `submitted_at` for reviews) is strictly greater than
                  the triggering event's timestamp. The fallback chain
-                 prefers exact creation/submission timestamps and only
-                 falls back to `issue.updated_at` for `issues` events
-                 with type `assigned` (the only trigger where
-                 `created_at` is not the right signal, since the issue
-                 itself wasn't created by this event):
+                 below picks the most-specific signal available for
+                 each event type:
                  (`${{ github.event.comment.created_at || github.event.review.submitted_at || (github.event_name == 'issues' && github.event.action == 'opened' && github.event.issue.created_at) || github.event.issue.updated_at }}`)
+                 Per the current `on:` triggers, that resolves to:
+                 `comment.created_at` for `issue_comment` and
+                 `pull_request_review_comment`; `review.submitted_at`
+                 for `pull_request_review`; `issue.created_at` for
+                 `issues:opened`; and the final `issue.updated_at`
+                 fallback for `issues:assigned`. The chain is a
+                 `||`-cascade, so any future event type added to
+                 `on:` without matching logic will also land on
+                 `issue.updated_at` — reassess this expression when
+                 changing the trigger list.
                - the relevant text field (`body` for comments and
                  reviews) contains `@claude`
                - `user.type` is not `"Bot"` — this generically excludes

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -189,7 +189,7 @@ jobs:
           # allowlist. `Bash(gh pr view:*)` and `Bash(gh issue view:*)`
           # are strict subsets (the CLI commands hit the same API
           # internally), so they're omitted.
-          GH_TOOLS="Bash(gh api repos/${{ github.repository }}/:*)"
+          GH_TOOLS="Bash(gh api repos/${{ github.repository }}/*)"
           if [ -n "$WEBFETCH" ]; then
             echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
           else
@@ -242,7 +242,12 @@ jobs:
             any of them. Poll the endpoints that apply to your trigger
             type before finishing.
 
-            This run was triggered by a `${{ github.event_name }}` event:
+            This run was triggered by a `${{ github.event_name }}` event.
+            Pre-resolved context (you don't need to figure these out yourself):
+            - PR context? `${{ (github.event.pull_request.number || github.event.issue.pull_request) && 'yes' || 'no' }}`
+              (`issue_comment` fires for both issues and PRs; this
+              flag disambiguates without you guessing.)
+            - Entity number: `${{ github.event.issue.number || github.event.pull_request.number }}`
 
             - **PR triggers** (`issue_comment` on a PR,
               `pull_request_review`, `pull_request_review_comment`):

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,6 +17,17 @@ on:
 # 2026-05-19 18:31–18:39 window, where 2 of 4 races were blocked).
 # `cancel-in-progress: false` means each new comment QUEUES behind the
 # running session rather than starting a competing one.
+#
+# Known limitation — queued runs may re-handle absorbed comments:
+# if comment 2 arrives while run A (triggered by comment 1) is
+# active, run A's polling step (see `prompt:` below) addresses
+# comment 2 in-session — but run B is also queued and will still
+# start once A finishes, re-addressing comment 2 as its triggering
+# event. In practice this costs at most an extra commit or a
+# no-op session; the tasks `@claude` performs here are idempotent
+# enough that the cost is acceptable. The alternative
+# (`cancel-in-progress: true`) would throw away in-flight work,
+# which is worse than the occasional duplicate.
 concurrency:
   # `github.event.pull_request.number` is already populated for
   # `pull_request_review` and `pull_request_review_comment` events, so
@@ -209,7 +220,21 @@ jobs:
 
             The three event types that trigger this workflow each live at
             a different GitHub API endpoint, and `@claude` can appear in
-            any of them. Poll all three before finishing:
+            any of them. Poll the endpoints that apply to your trigger
+            type before finishing.
+
+            This run was triggered by a `${{ github.event_name }}` event:
+
+            - **PR triggers** (`issue_comment` on a PR,
+              `pull_request_review`, `pull_request_review_comment`):
+              poll all three endpoints listed below.
+            - **Issue triggers** (`issue_comment` on an issue,
+              `issues`): poll **only** `/issues/N/comments`; the
+              `/pulls/...` endpoints don't apply, and the issue body
+              itself doesn't admit late-arriving `@claude` content
+              (there's typically nothing else to poll anyway).
+
+            Endpoints:
 
             - `/issues/N/comments` — PR/issue **timeline** comments
               (covers `issue_comment` and the issue body on `issues`).
@@ -218,14 +243,6 @@ jobs:
             - `/pulls/N/reviews` — PR **review submissions**; the
               `body` field here is where `@claude` lives for a
               `pull_request_review` trigger.
-
-            This run was triggered by a `${{ github.event_name }}`
-            event; the `/pulls/...` endpoints below only apply when the
-            triggering event was on a PR — i.e. when the event type is
-            **not** `issues`. Skip those two endpoints for `issues`
-            triggers (the issue body itself doesn't admit late-arriving
-            `@claude` content, so there's typically nothing to poll
-            anyway).
 
             1. Fetch each endpoint (skip the `/pulls/...` ones for
                `issues` triggers — the GitHub-Actions expression

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,14 @@ on:
 # `cancel-in-progress: false` means each new comment QUEUES behind the
 # running session rather than starting a competing one.
 concurrency:
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.event.review.pull_request_url }}
+  # `github.event.pull_request.number` is already populated for
+  # `pull_request_review` and `pull_request_review_comment` events, so
+  # the two fallbacks below cover all four trigger types — no third
+  # clause needed. A stray `github.event.review.pull_request_url`
+  # fallback would also be wrong: it's a full API URL string, not a
+  # number, so it would produce a different group than the `claude-N`
+  # used by `issue_comment` events on the same PR.
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
@@ -147,6 +154,17 @@ jobs:
           # session checks for late-arriving @claude comments before
           # declaring done, so multi-comment bursts get handled in a
           # single session instead of racing parallel runs.
+          #
+          # `Bash(gh api:*)` is intentionally broad: the polling step
+          # only needs GET on a few endpoints, but Claude often uses
+          # `gh api` for other read-only inspection during a session
+          # (e.g. fetching file SHAs, reading raw PR metadata). The
+          # allowed-tools pattern doesn't currently support a clean way
+          # to restrict to GET-only or to a specific endpoint path,
+          # so we accept the broader surface. The ultimate bound on
+          # what's possible is still `GITHUB_TOKEN`'s scopes
+          # (`contents: write`, `pull-requests: write`, `issues: write`),
+          # not this allowlist.
           GH_TOOLS='Bash(gh api:*),Bash(gh pr view:*),Bash(gh issue view:*)'
           if [ -n "$WEBFETCH" ]; then
             echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
@@ -180,24 +198,49 @@ jobs:
             comment/issue/review.
 
             **Before declaring the task complete, check for additional
-            @claude requests that arrived after the triggering event:**
+            @claude requests that arrived after the triggering event.**
 
-            1. Fetch the latest issue/PR comments:
-               `gh api 'repos/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}/comments' --paginate`
-               (PR review comments also live at this endpoint; the
-               separate `/pulls/N/comments` endpoint is only for inline
-               review-thread replies.)
+            The three event types that trigger this workflow each live at
+            a different GitHub API endpoint, and `@claude` can appear in
+            any of them. Poll all three before finishing:
 
-            2. From the response, identify comments where ALL of:
-               - `created_at` is strictly greater than the triggering
-                 comment's timestamp
+            - `/issues/N/comments` — PR/issue **timeline** comments
+              (covers `issue_comment` and the issue body on `issues`).
+            - `/pulls/N/comments` — **inline review-thread** comments
+              on a PR (covers `pull_request_review_comment`).
+            - `/pulls/N/reviews` — PR **review submissions**; the
+              `body` field here is where `@claude` lives for a
+              `pull_request_review` trigger.
+
+            Treat N = `${{ github.event.issue.number || github.event.pull_request.number }}`.
+
+            1. Fetch each endpoint (skip the `/pulls/...` ones if N is
+               an issue rather than a PR):
+               ```
+               gh api 'repos/${{ github.repository }}/issues/N/comments' --paginate
+               gh api 'repos/${{ github.repository }}/pulls/N/comments' --paginate   # PRs only
+               gh api 'repos/${{ github.repository }}/pulls/N/reviews'  --paginate   # PRs only
+               ```
+
+            2. From the combined response, identify entries where ALL of:
+               - the relevant timestamp (`created_at` for comments,
+                 `submitted_at` for reviews) is strictly greater than
+                 the triggering event's timestamp
                  (`${{ github.event.comment.created_at || github.event.review.submitted_at || github.event.issue.updated_at }}`)
-               - body contains `@claude`
-               - user.login is neither `claude[bot]` nor `github-actions[bot]`
+               - the relevant text field (`body` for comments and
+                 reviews) contains `@claude`
+               - `user.login` is neither `claude[bot]` nor
+                 `github-actions[bot]`
 
-            3. If any matching comments exist, address each one in this
+               Note: for `issues` events the triggering timestamp falls
+               back to `issue.updated_at`, which is a coarse signal
+               (any update — assignment, label change, etc. — bumps it).
+               Comments posted in the same second as another issue
+               update could be missed; this is rare but not impossible.
+
+            3. If any matching entries exist, address each one in this
                same session (in chronological order), then repeat from
-               step 1. Stop when no new @claude comments remain.
+               step 1. Stop when no new @claude requests remain.
 
             4. Push all commits before finishing. The concurrency group
                guarantees no parallel session is racing yours, so


### PR DESCRIPTION
## Summary

Closes the silent-data-loss race condition on `.github/workflows/claude.yml` that surfaced on PR #706 (2026-05-19 18:31–18:39): four rapid `@claude` comments fired four parallel runs, all pushed to the same branch, and the action's `git-push.sh` refused non-fast-forward pushes — silently dropping 2 of the 4 runs' work. The blocked run's own follow-up comment noted "*The previous job that attempted issue 2 was blocked from pushing.*"

## Changes

**1. Workflow-level `concurrency` block**

```yaml
concurrency:
  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
  cancel-in-progress: false
```

Only one `@claude` session runs per issue/PR at a time. `cancel-in-progress: false` means new comments **queue** behind the running session instead of starting a competing one — so the race condition that dropped pushes can't happen anymore.

**2. Polling prompt**

The `claude-code-action` invocation now passes an explicit `prompt:` that instructs Claude, before declaring the task done, to:

1. Poll the GitHub API endpoints that apply to the trigger type (`/issues/N/comments` always; `/pulls/N/comments` and `/pulls/N/reviews` for PR triggers).
2. Find `@claude` mentions with a relevant timestamp (`created_at` for comments, `submitted_at` for reviews) strictly after the triggering event's timestamp, posted by a non-bot user.
3. Address each in the same session, in chronological order.
4. Repeat until no newer `@claude` mentions remain, or until a 5-round cap is hit.

The concurrency block alone prevents parallel races, but a long-running session could still miss a comment that arrives mid-session. Polling fills that gap so a single session handles a whole burst of comments.

**3. Supporting allowed-tools change**

Added `Bash(gh api repos/${{ github.repository }}/:*)` to the action's allowed-tools so the polling step can call the GitHub API for this repo's endpoints. The pattern is scoped to the current repo, so cross-repo / cross-org `gh api` calls (e.g. `/user`, `/orgs/...`, `/repos/OTHER/...`) are not reachable. (`Bash(gh pr view:*)` and `Bash(gh issue view:*)` are strict subsets of `gh api` against this repo, and are omitted.)

## Known limitations / surface notes

- **Queued runs may re-handle a comment the active session already absorbed.** If comment 2 arrives while run A (triggered by comment 1) is still running, run A's polling step addresses comment 2 in-session, but run B was already queued and will still start when A finishes, re-addressing comment 2. In practice this costs at most an extra commit, an extra "*Claude finished @user's task*" comment, or a no-op session. Documented inline near `cancel-in-progress: false`. The alternative (`cancel-in-progress: true`) would throw away in-flight work, which is worse than the occasional duplicate.
- **`Bash(gh api repos/<this-repo>/:*)` matches write methods too.** The polling step only needs GETs, but allowed-tools doesn't currently support HTTP-method filtering. The grant therefore also allows `gh api -X POST/PATCH/DELETE repos/<this-repo>/...` — e.g. deleting a comment or editing an issue body from within a session. The ultimate bound on impact is `GITHUB_TOKEN`'s scopes (`contents: write`, `pull-requests: write`, `issues: write`), not this allowlist; nothing here grants new repo or org access. Documented inline near the `GH_TOOLS=...` line.

## Test plan

- [ ] After merge, post two `@claude` comments back-to-back on a test PR; verify the second run queues (rather than racing) per the Actions UI, and that the eventual session addresses both comments.
- [ ] Verify a single `@claude` invocation still works as before (no behavioral regression for the common case).
- [ ] Verify the queued duplicate-handling case is at worst a no-op session, not a regression that produces conflicting commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
