### PR TITLE
feat: add floating "collapse all" button for callout boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *_files/
 site_libs/
 *.html
+!collapse-all-button.html
 *.pdf
 *-handout.docx
 *.aux

--- a/_quarto-book.yml
+++ b/_quarto-book.yml
@@ -82,6 +82,7 @@ format:
     toc-depth: 3
     code-summary: "Show R code"
     css: custom.scss
+    include-after-body: collapse-all-button.html
   pdf:
     geometry:
       - top=15mm

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -245,6 +245,7 @@ format:
     date: last-modified
     date-format: "[Last modified:] YYYY-MM-DD: H:mm:ss (z)"
     subject: "Epidemiology 204"
+    include-after-body: collapse-all-button.html
   revealjs:
     filters:
       - filters/revealjs-slidebreak-after-h1.lua

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -103,7 +103,7 @@
       btn.style.display = "none";
       return;
     }
-    btn.style.display = "";
+    btn.style.display = "block";
 
     if (anyExpanded()) {
       if (iconPath) {

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -3,7 +3,7 @@
   class="btn btn-sm btn-outline-secondary"
   title="Collapse all expandable boxes"
   aria-label="Collapse all expandable boxes"
-  aria-expanded="true"
+  aria-expanded="false"
 >
   <svg
     id="collapse-all-icon"
@@ -20,7 +20,7 @@
       d="M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8m7-8a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 4.293V.5A.5.5 0 0 1 8 0m-.5 11.707-1.146 1.147a.5.5 0 0 1-.708-.708l2-2a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 11.707V15.5a.5.5 0 0 1-1 0z"
     />
   </svg>
-  <span id="collapse-all-label"> Collapse all</span>
+  <span id="collapse-all-label">Collapse all</span>
 </button>
 
 <style>
@@ -34,6 +34,10 @@
   transition: opacity 0.15s ease-in-out;
   white-space: nowrap;
   display: none; /* hidden until JS confirms collapsibles exist */
+}
+
+#collapse-all-btn #collapse-all-label {
+  margin-left: 0.25rem;
 }
 
 #collapse-all-btn:hover {
@@ -110,7 +114,7 @@
         iconPath.setAttribute("d", COLLAPSE_ICON_PATH);
       }
       btn.setAttribute("aria-expanded", "true");
-      label.textContent = " Collapse all";
+      label.textContent = "Collapse all";
       btn.title = "Collapse all expandable boxes";
       btn.setAttribute("aria-label", "Collapse all expandable boxes");
     } else {
@@ -118,7 +122,7 @@
         iconPath.setAttribute("d", EXPAND_ICON_PATH);
       }
       btn.setAttribute("aria-expanded", "false");
-      label.textContent = " Expand all";
+      label.textContent = "Expand all";
       btn.title = "Expand all collapsible boxes";
       btn.setAttribute("aria-label", "Expand all collapsible boxes");
     }
@@ -184,7 +188,8 @@
         updateButtonState();
       });
     });
-    observer.observe(document.body, {
+    var observeRoot = document.querySelector("main") || document.body;
+    observer.observe(observeRoot, {
       subtree: true,
       attributes: true,
       attributeFilter: ["class", "open"],

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -3,6 +3,7 @@
   class="btn btn-sm btn-outline-secondary"
   title="Collapse all expandable boxes"
   aria-label="Collapse all expandable boxes"
+  aria-expanded="true"
 >
   <svg
     id="collapse-all-icon"
@@ -72,7 +73,8 @@
   }
 
   function getDetailsElements() {
-    return Array.from(document.querySelectorAll("details"));
+    var root = document.querySelector("main") || document.body;
+    return Array.from(root.querySelectorAll("details"));
   }
 
   function hasAnyCollapsibles() {
@@ -107,6 +109,7 @@
       if (iconPath) {
         iconPath.setAttribute("d", COLLAPSE_ICON_PATH);
       }
+      btn.setAttribute("aria-expanded", "true");
       label.textContent = " Collapse all";
       btn.title = "Collapse all expandable boxes";
       btn.setAttribute("aria-label", "Collapse all expandable boxes");
@@ -114,6 +117,7 @@
       if (iconPath) {
         iconPath.setAttribute("d", EXPAND_ICON_PATH);
       }
+      btn.setAttribute("aria-expanded", "false");
       label.textContent = " Expand all";
       btn.title = "Expand all collapsible boxes";
       btn.setAttribute("aria-label", "Expand all collapsible boxes");
@@ -172,8 +176,13 @@
 
     updateButtonState();
 
+    var rafId = null;
     var observer = new MutationObserver(function () {
-      updateButtonState();
+      if (rafId) return;
+      rafId = requestAnimationFrame(function () {
+        rafId = null;
+        updateButtonState();
+      });
     });
     observer.observe(document.body, {
       subtree: true,

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -95,7 +95,15 @@
     return bsAny || detailsAny;
   }
 
-  function updateButtonState() {
+  // `forceExpanded` (optional boolean) overrides the anyExpanded() probe
+  // for the button's expanded/collapsed UI. Callers that just *triggered*
+  // a state change (collapseAll/expandAll) pass the new state directly so
+  // the button label flips synchronously, instead of waiting one rAF for
+  // Bootstrap's hide()/show() transition to remove/add `.show` and the
+  // MutationObserver to react. Without `forceExpanded`, this falls back
+  // to anyExpanded() — the right behavior for page-load init and for
+  // manual user toggles on individual callouts that bypass our buttons.
+  function updateButtonState(forceExpanded) {
     var btn = document.getElementById("collapse-all-btn");
     var iconPath = document.querySelector("#collapse-all-icon path");
     var label = document.getElementById("collapse-all-label");
@@ -109,7 +117,11 @@
     }
     btn.style.display = "block";
 
-    if (anyExpanded()) {
+    var isExpanded = (forceExpanded !== undefined)
+      ? forceExpanded
+      : anyExpanded();
+
+    if (isExpanded) {
       if (iconPath) {
         iconPath.setAttribute("d", COLLAPSE_ICON_PATH);
       }
@@ -143,7 +155,7 @@
     getDetailsElements().forEach(function (el) {
       el.open = false;
     });
-    updateButtonState();
+    updateButtonState(false);
   }
 
   function expandAll() {
@@ -161,7 +173,7 @@
     getDetailsElements().forEach(function (el) {
       el.open = true;
     });
-    updateButtonState();
+    updateButtonState(true);
   }
 
   document.addEventListener("DOMContentLoaded", function () {

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -1,0 +1,185 @@
+<button
+  id="collapse-all-btn"
+  class="btn btn-sm btn-outline-secondary"
+  title="Collapse all expandable boxes"
+  aria-label="Collapse all expandable boxes"
+>
+  <svg
+    id="collapse-all-icon"
+    xmlns="http://www.w3.org/2000/svg"
+    width="12"
+    height="12"
+    fill="currentColor"
+    viewBox="0 0 16 16"
+    aria-hidden="true"
+  >
+    <!-- arrows-collapse icon (default) -->
+    <path
+      fill-rule="evenodd"
+      d="M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8m7-8a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 4.293V.5A.5.5 0 0 1 8 0m-.5 11.707-1.146 1.147a.5.5 0 0 1-.708-.708l2-2a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 11.707V15.5a.5.5 0 0 1-1 0z"
+    />
+  </svg>
+  <span id="collapse-all-label"> Collapse all</span>
+</button>
+
+<style>
+#collapse-all-btn {
+  position: fixed;
+  bottom: 4rem;
+  right: 1rem;
+  z-index: 1030;
+  opacity: 0.75;
+  font-size: 0.75rem;
+  transition: opacity 0.15s ease-in-out;
+  white-space: nowrap;
+  display: none; /* hidden until JS confirms collapsibles exist */
+}
+
+#collapse-all-btn:hover {
+  opacity: 1;
+}
+
+@media (max-width: 767px) {
+  #collapse-all-btn {
+    bottom: 1rem;
+  }
+}
+</style>
+
+<script>
+(function () {
+  "use strict";
+
+  var COLLAPSE_ICON_PATH =
+    "M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8m7-8a.5.5 0 0 1 " +
+    ".5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 " +
+    "0 0 1 .708-.708L7.5 4.293V.5A.5.5 0 0 1 8 0m-.5 11.707-1.146 1.147a.5.5 0 0 " +
+    "1-.708-.708l2-2a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 11.707V15.5a.5.5 " +
+    "0 0 1-1 0z";
+
+  var EXPAND_ICON_PATH =
+    "M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8M7.646.146a.5.5 0 " +
+    "0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 1.707V5.5a.5.5 0 0 1-1 0V1.707L6.354 " +
+    "2.854a.5.5 0 1 1-.708-.708zm-1.292 13l-1.146-1.146a.5.5 0 0 0-.708.708l2 2a.5.5 " +
+    "0 0 0 .708 0l2-2a.5.5 0 0 0-.708-.708L8.5 14.293V10.5a.5.5 0 0 0-1 0v3.793z";
+
+  function getCalloutCollapsibles() {
+    return Array.from(
+      document.querySelectorAll(".callout-collapse.collapse")
+    ).filter(function (el) {
+      return !el.classList.contains("navbar-collapse");
+    });
+  }
+
+  function getDetailsElements() {
+    return Array.from(document.querySelectorAll("details"));
+  }
+
+  function hasAnyCollapsibles() {
+    return getCalloutCollapsibles().length > 0 || getDetailsElements().length > 0;
+  }
+
+  function anyExpanded() {
+    var bsAny = getCalloutCollapsibles().some(function (el) {
+      return el.classList.contains("show");
+    });
+    var detailsAny = getDetailsElements().some(function (el) {
+      return el.open;
+    });
+    return bsAny || detailsAny;
+  }
+
+  function updateButtonState() {
+    var btn = document.getElementById("collapse-all-btn");
+    var iconPath = document.querySelector("#collapse-all-icon path");
+    var label = document.getElementById("collapse-all-label");
+    if (!btn) {
+      return;
+    }
+
+    if (!hasAnyCollapsibles()) {
+      btn.style.display = "none";
+      return;
+    }
+    btn.style.display = "";
+
+    if (anyExpanded()) {
+      if (iconPath) {
+        iconPath.setAttribute("d", COLLAPSE_ICON_PATH);
+      }
+      label.textContent = " Collapse all";
+      btn.title = "Collapse all expandable boxes";
+      btn.setAttribute("aria-label", "Collapse all expandable boxes");
+    } else {
+      if (iconPath) {
+        iconPath.setAttribute("d", EXPAND_ICON_PATH);
+      }
+      label.textContent = " Expand all";
+      btn.title = "Expand all collapsible boxes";
+      btn.setAttribute("aria-label", "Expand all collapsible boxes");
+    }
+  }
+
+  function collapseAll() {
+    getCalloutCollapsibles().forEach(function (el) {
+      if (el.classList.contains("show")) {
+        if (window.bootstrap && window.bootstrap.Collapse) {
+          window.bootstrap.Collapse.getOrCreateInstance(el, {
+            toggle: false,
+          }).hide();
+        } else {
+          el.classList.remove("show");
+        }
+      }
+    });
+    getDetailsElements().forEach(function (el) {
+      el.open = false;
+    });
+    updateButtonState();
+  }
+
+  function expandAll() {
+    getCalloutCollapsibles().forEach(function (el) {
+      if (!el.classList.contains("show")) {
+        if (window.bootstrap && window.bootstrap.Collapse) {
+          window.bootstrap.Collapse.getOrCreateInstance(el, {
+            toggle: false,
+          }).show();
+        } else {
+          el.classList.add("show");
+        }
+      }
+    });
+    getDetailsElements().forEach(function (el) {
+      el.open = true;
+    });
+    updateButtonState();
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var btn = document.getElementById("collapse-all-btn");
+    if (!btn) {
+      return;
+    }
+
+    btn.addEventListener("click", function () {
+      if (anyExpanded()) {
+        collapseAll();
+      } else {
+        expandAll();
+      }
+    });
+
+    updateButtonState();
+
+    var observer = new MutationObserver(function () {
+      updateButtonState();
+    });
+    observer.observe(document.body, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["class", "open"],
+    });
+  });
+})();
+</script>

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -3,7 +3,7 @@
   class="btn btn-sm btn-outline-secondary"
   title="Collapse all expandable boxes"
   aria-label="Collapse all expandable boxes"
-  aria-expanded="false"
+  aria-expanded="true"
 >
   <svg
     id="collapse-all-icon"
@@ -55,12 +55,20 @@
 (function () {
   "use strict";
 
-  var COLLAPSE_ICON_PATH =
-    "M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8m7-8a.5.5 0 0 1 " +
-    ".5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 " +
-    "0 0 1 .708-.708L7.5 4.293V.5A.5.5 0 0 1 8 0m-.5 11.707-1.146 1.147a.5.5 0 0 " +
-    "1-.708-.708l2-2a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 11.707V15.5a.5.5 " +
-    "0 0 1-1 0z";
+  // Lazy: read the initial collapse-icon path from the DOM on first use
+  // instead of duplicating the path string in JS. This keeps the icon
+  // definition in one place (the inline <svg> above) — if the SVG ever
+  // changes, the JS picks up the new path automatically. The expand-icon
+  // path doesn't appear in the static HTML (it's only swapped in by JS),
+  // so it stays inline below.
+  var COLLAPSE_ICON_PATH = null;
+  function getCollapseIconPath() {
+    if (COLLAPSE_ICON_PATH === null) {
+      var pathEl = document.querySelector("#collapse-all-icon path");
+      COLLAPSE_ICON_PATH = (pathEl && pathEl.getAttribute("d")) || "";
+    }
+    return COLLAPSE_ICON_PATH;
+  }
 
   var EXPAND_ICON_PATH =
     "M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8M7.646.146a.5.5 0 " +
@@ -68,17 +76,23 @@
     "2.854a.5.5 0 1 1-.708-.708zm-1.292 13l-1.146-1.146a.5.5 0 0 0-.708.708l2 2a.5.5 " +
     "0 0 0 .708 0l2-2a.5.5 0 0 0-.708-.708L8.5 14.293V10.5a.5.5 0 0 0-1 0v3.793z";
 
+  // Both collapsibles and <details> are scoped to `<main>` so we never
+  // accidentally toggle a `.navbar-collapse` (Bootstrap's mobile-menu
+  // pattern) or a sidebar `<details>`. Falling back to `document.body`
+  // for pages without a `<main>` keeps the button working on landing
+  // pages too.
+  function getRoot() {
+    return document.querySelector("main") || document.body;
+  }
+
   function getCalloutCollapsibles() {
     return Array.from(
-      document.querySelectorAll(".callout-collapse.collapse")
-    ).filter(function (el) {
-      return !el.classList.contains("navbar-collapse");
-    });
+      getRoot().querySelectorAll(".callout-collapse.collapse")
+    );
   }
 
   function getDetailsElements() {
-    var root = document.querySelector("main") || document.body;
-    return Array.from(root.querySelectorAll("details"));
+    return Array.from(getRoot().querySelectorAll("details"));
   }
 
   function hasAnyCollapsibles() {
@@ -123,7 +137,7 @@
 
     if (isExpanded) {
       if (iconPath) {
-        iconPath.setAttribute("d", COLLAPSE_ICON_PATH);
+        iconPath.setAttribute("d", getCollapseIconPath());
       }
       btn.setAttribute("aria-expanded", "true");
       label.textContent = "Collapse all";
@@ -200,8 +214,7 @@
         updateButtonState();
       });
     });
-    var observeRoot = document.querySelector("main") || document.body;
-    observer.observe(observeRoot, {
+    observer.observe(getRoot(), {
       subtree: true,
       attributes: true,
       attributeFilter: ["class", "open"],

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -121,7 +121,10 @@
     var btn = document.getElementById("collapse-all-btn");
     var iconPath = document.querySelector("#collapse-all-icon path");
     var label = document.getElementById("collapse-all-label");
-    if (!btn) {
+    // Guard on both btn and label — they're in the same HTML fragment so
+    // in practice both are always present or both are always absent, but
+    // a missing `label` would throw on `label.textContent = ...` below.
+    if (!btn || !label) {
       return;
     }
 

--- a/collapse-all-button.html
+++ b/collapse-all-button.html
@@ -135,23 +135,30 @@
       ? forceExpanded
       : anyExpanded();
 
-    if (isExpanded) {
-      if (iconPath) {
-        iconPath.setAttribute("d", getCollapseIconPath());
-      }
-      btn.setAttribute("aria-expanded", "true");
-      label.textContent = "Collapse all";
-      btn.title = "Collapse all expandable boxes";
-      btn.setAttribute("aria-label", "Collapse all expandable boxes");
-    } else {
-      if (iconPath) {
-        iconPath.setAttribute("d", EXPAND_ICON_PATH);
-      }
-      btn.setAttribute("aria-expanded", "false");
-      label.textContent = "Expand all";
-      btn.title = "Expand all collapsible boxes";
-      btn.setAttribute("aria-label", "Expand all collapsible boxes");
+    // Single source of truth for the two UI states. Keeps `title` and
+    // `aria-label` aligned — a previous version kept them in sync via
+    // four hand-edited string literals, two per branch.
+    var ui = isExpanded
+      ? {
+          iconPath: getCollapseIconPath(),
+          ariaExpanded: "true",
+          label: "Collapse all",
+          phrase: "Collapse all expandable boxes",
+        }
+      : {
+          iconPath: EXPAND_ICON_PATH,
+          ariaExpanded: "false",
+          label: "Expand all",
+          phrase: "Expand all collapsible boxes",
+        };
+
+    if (iconPath) {
+      iconPath.setAttribute("d", ui.iconPath);
     }
+    btn.setAttribute("aria-expanded", ui.ariaExpanded);
+    label.textContent = ui.label;
+    btn.title = ui.phrase;
+    btn.setAttribute("aria-label", ui.phrase);
   }
 
   function collapseAll() {


### PR DESCRIPTION
Adds a floating "Collapse all" / "Expand all" button (bottom-right) that toggles all Bootstrap callout collapsibles (.callout-collapse) and native <details> elements (code folds) on each page.

The button is hidden on pages with no collapsible content, and syncs with manual toggles via MutationObserver.

Closes #763

Generated with [Claude Code](https://claude.ai/code)