### PR TITLE
claude.yml: clarify /issues/N/comments endpoint description

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -261,7 +261,10 @@ jobs:
             Endpoints:
 
             - `/issues/N/comments` — PR/issue **timeline** comments
-              (covers `issue_comment` and the issue body on `issues`).
+              (covers `issue_comment` events; this endpoint does NOT
+              contain the issue body itself, which lives at
+              `/issues/N` and is already supplied to you by the
+              action's default prompt — no need to re-fetch).
             - `/pulls/N/comments` — **inline review-thread** comments
               on a PR (covers `pull_request_review_comment`).
             - `/pulls/N/reviews` — PR **review submissions**; the


### PR DESCRIPTION
## Summary

Follow-up to [#764](https://github.com/d-morrison/rme/pull/764), addressing the one nit from its round-9 claude-review that didn't land before merge.

In the polling-prompt's endpoint list, line 263–264 said:

> - \`/issues/N/comments\` — PR/issue **timeline** comments
>   (covers \`issue_comment\` and the issue body on \`issues\`).

The phrase "the issue body on \`issues\`" wrongly implied the issue body lives in \`/issues/N/comments\`. The body actually lives at \`/issues/N\` and is already supplied by the action's default prompt — no need to re-fetch via the comments endpoint.

New wording is explicit so a future reader (Claude or human) doesn't try to pull the body from /comments.

## Test plan

- [ ] No behavioural change — comment-only edit inside a prompt block. CI green is sufficient.
- [ ] @claude review confirms fully-blank verdict on the latest SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)