### PR TITLE
claude.yml: pass GITHUB_PAT to setup-renv so @claude can actually run

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -121,6 +121,12 @@ jobs:
 
       - name: Install R dependencies via renv
         uses: r-lib/actions/setup-renv@v2
+        env:
+          # Without GITHUB_PAT, renv can't hit the GitHub API to resolve
+          # GitHub-sourced packages (e.g. `ddsjoberg/gtsummary`) and
+          # `renv::restore()` aborts with "GitHub authentication
+          # credentials are not available." Matches publish.yml.
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         with:
           cache-version: 1
 


### PR DESCRIPTION
## Summary

- `r-lib/actions/setup-renv@v2` in `claude.yml` was being invoked without `GITHUB_PAT`, so `renv::restore()` couldn't authenticate to the GitHub API to resolve GitHub-sourced packages (e.g. `ddsjoberg/gtsummary`)
- Every `@claude` invocation has been silently dying at the renv step before Claude itself ever ran
- This PR adds the same three-line `env:` block already used in [publish.yml](.github/workflows/publish.yml)

## Evidence

`@claude` on [#775](https://github.com/d-morrison/rme/issues/775) at 2026-05-20T06:06:01Z → run [26144678107](https://github.com/d-morrison/rme/actions/runs/26144678107) failed at step `Install R dependencies via renv` with:

```
GitHub authentication credentials are not available.
Please set GITHUB_PAT, or ensure the 'gitcreds' package is installed.
Error: failed to resolve remote 'ddsjoberg/gtsummary' --
  error downloading 'https://api.github.com/repos/ddsjoberg/gtsummary' [error code 22]
```

## Test plan

- [ ] CI on this PR passes
- [ ] After merge, post `@claude` on [#775](https://github.com/d-morrison/rme/issues/775) and confirm the workflow reaches the `Run Claude Code` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)