### PR TITLE
intro-to-survival: lift Greenwood out of #exm-bmt to unblock Quarto 1.9.37 publish

### DIFF
--- a/_subfiles/intro-to-survival-analysis/_sec-greenwood.qmd
+++ b/_subfiles/intro-to-survival-analysis/_sec-greenwood.qmd
@@ -20,7 +20,7 @@ difference of survival functions.
 
 {{< slidebreak >}}
 
-##### Understanding Greenwood's formula (optional)
+## Understanding Greenwood's formula (optional)
 
 ::: notes
 To see where Greenwood's formula comes from, let $x_i = Y_i - d_i$. We

--- a/_subfiles/intro-to-survival-analysis/_sec-greenwood.qmd
+++ b/_subfiles/intro-to-survival-analysis/_sec-greenwood.qmd
@@ -1,0 +1,64 @@
+The Kaplan-Meier estimator of the survival function is
+
+$$\hsurv(t) = \prod_{t_i \le t}\sb{1-\frac{d_i}{r_i}}$$
+
+where $r_i$ is the number at risk at time $t_i$.
+
+The estimated variance of $\hsurv(t)$ is:
+
+:::{#thm-greenwood}
+#### Greenwood's estimator for variance of Kaplan-Meier survival estimator
+
+$$
+\varhf{\hsurv(t)} = \hsurv(t)^2\sum_{t_i \le t}\frac{d_i}{r_i(r_i-d_i)}
+$${#eq-var-est-surv}
+:::
+
+
+We can use @eq-var-est-surv for confidence intervals for a survival function or a
+difference of survival functions.
+
+{{< slidebreak >}}
+
+##### Understanding Greenwood's formula (optional)
+
+::: notes
+To see where Greenwood's formula comes from, let $x_i = Y_i - d_i$. We
+approximate the solution treating each time as independent, with $Y_i$
+fixed and ignore randomness in times of failure and we treat $x_i$ as
+independent binomials $\text{Bin}(Y_i,p_i)$. Letting $\surv(t)$ be the
+"true" survival function
+:::
+
+$$
+\begin{aligned}
+\hsurv(t) &=\prod_{t_i \le t}x_i/Y_i\\
+\surv(t)&=\prod_{t_i \le t}p_i
+\end{aligned}
+$$
+
+$$
+\begin{aligned}
+\frac{\hsurv(t)}{\surv(t)}
+&= \prod_{t_i \le t} \frac{x_i}.    {p_iY_i}
+\\ &= \prod_{t_i \le t} \frac{\hat p_i}{p_i}
+\\ &= \prod_{t_i \le t} \paren{1+\frac{\hat p_i-p_i}{p_i}}
+\\ &\approx 1+\sum_{t_i \le t} \frac{\hat p_i-p_i}{p_i}
+\end{aligned}
+$$
+
+{{< slidebreak >}}
+
+$$
+\begin{aligned}
+\text{Var}\left(\frac{\hsurv(t)}{\surv(t)}\right)
+&\approx \text{Var}\left(1+\sum_{t_i \le t} \frac{\hat p_i-p_i}{p_i}\right)
+\\ &=\sum_{t_i \le t} \frac{1}{p_i^2}\frac{p_i(1-p_i)}{Y_i}
+\\ &= \sum_{t_i \le t} \frac{(1-p_i)}{p_iY_i}
+\\ &\approx\sum_{t_i \le t} \frac{(1-x_i/Y_i)}{x_i}
+\\ &=\sum_{t_i \le t} \frac{Y_i-x_i}{x_iY_i}
+\\ &=\sum_{t_i \le t} \frac{d_i}{Y_i(Y_i-d_i)}
+\\ \tf \Varf{\hsurv(t)}
+&\approx \hsurv(t)^2\sum_{t_i \le t} \frac{d_i}{Y_i(Y_i-d_i)}
+\end{aligned}
+$$

--- a/_subfiles/intro-to-survival-analysis/_sec-surv-exm-bmt.qmd
+++ b/_subfiles/intro-to-survival-analysis/_sec-surv-exm-bmt.qmd
@@ -45,28 +45,11 @@ and test for differences.
 -   We will construct the cumulative hazard curves and compare them.
 -   We will estimate the hazard functions, interpret, and compare them.
 
-##### Survival Function Estimate and Variance
+##### Kaplan-Meier survival curves
 
-$$\hsurv(t) = \prod_{t_i \le t}\sb{1-\frac{d_i}{r_i}}$$ where
-$r_i$ is the number at risk at time $t_i$.
-
-The estimated variance of $\hsurv(t)$ is:
-
-:::{#thm-greenwood}
-#### Greenwood's estimator for variance of Kaplan-Meier survival estimator
-
-$$
-\varhf{\hsurv(t)} = \hsurv(t)^2\sum_{t_i \le t}\frac{d_i}{r_i(r_i-d_i)}
-$${#eq-var-est-surv}
-:::
-
-
-We can use @eq-var-est-surv for confidence intervals for a survival function or a
-difference of survival functions.
-
-{{< slidebreak >}}
-
-###### Kaplan-Meier survival curves
+We apply the Kaplan-Meier estimator $\hsurv(t)$ and its
+Greenwood-formula variance (see @thm-greenwood, above) to the
+BMT data:
 
 ```{r}
 #| code-summary: "code to preprocess and model `bmt` data"
@@ -105,51 +88,6 @@ autoplot(
   theme_bw() +
   theme(legend.position = "bottom")
 ```
-
-{{< slidebreak >}}
-
-##### Understanding Greenwood's formula (optional)
-
-::: notes
-To see where Greenwood's formula comes from, let $x_i = Y_i - d_i$. We
-approximate the solution treating each time as independent, with $Y_i$
-fixed and ignore randomness in times of failure and we treat $x_i$ as
-independent binomials $\text{Bin}(Y_i,p_i)$. Letting $\surv(t)$ be the
-"true" survival function
-:::
-
-$$
-\begin{aligned}
-\hsurv(t) &=\prod_{t_i \le t}x_i/Y_i\\
-\surv(t)&=\prod_{t_i \le t}p_i
-\end{aligned}
-$$
-
-$$
-\begin{aligned}
-\frac{\hsurv(t)}{\surv(t)}
-&= \prod_{t_i \le t} \frac{x_i}.    {p_iY_i}
-\\ &= \prod_{t_i \le t} \frac{\hat p_i}{p_i}
-\\ &= \prod_{t_i \le t} \paren{1+\frac{\hat p_i-p_i}{p_i}}
-\\ &\approx 1+\sum_{t_i \le t} \frac{\hat p_i-p_i}{p_i}
-\end{aligned}
-$$
-
-{{< slidebreak >}}
-
-$$
-\begin{aligned}
-\text{Var}\left(\frac{\hsurv(t)}{\surv(t)}\right)
-&\approx \text{Var}\left(1+\sum_{t_i \le t} \frac{\hat p_i-p_i}{p_i}\right)
-\\ &=\sum_{t_i \le t} \frac{1}{p_i^2}\frac{p_i(1-p_i)}{Y_i}
-\\ &= \sum_{t_i \le t} \frac{(1-p_i)}{p_iY_i}
-\\ &\approx\sum_{t_i \le t} \frac{(1-x_i/Y_i)}{x_i}
-\\ &=\sum_{t_i \le t} \frac{Y_i-x_i}{x_iY_i}
-\\ &=\sum_{t_i \le t} \frac{d_i}{Y_i(Y_i-d_i)}
-\\ \tf \Varf{\hsurv(t)}
-&\approx \hsurv(t)^2\sum_{t_i \le t} \frac{d_i}{Y_i(Y_i-d_i)}
-\end{aligned}
-$$
 
 ##### Test for differences among the disease groups
 

--- a/_subfiles/intro-to-survival-analysis/_sec-surv-exm-bmt.qmd
+++ b/_subfiles/intro-to-survival-analysis/_sec-surv-exm-bmt.qmd
@@ -48,7 +48,7 @@ and test for differences.
 ##### Kaplan-Meier survival curves
 
 We apply the Kaplan-Meier estimator $\hsurv(t)$ and its
-Greenwood-formula variance (see @thm-greenwood, above) to the
+Greenwood-formula variance (see @thm-greenwood) to the
 BMT data:
 
 ```{r}

--- a/chapters/intro-to-survival-analysis.qmd
+++ b/chapters/intro-to-survival-analysis.qmd
@@ -82,6 +82,12 @@ The term *survival analysis* is a bit misleading. Survival outcomes can sometime
 
 {{< slidebreak >}}
 
+# Greenwood's formula for the variance of the KM estimator
+
+{{< include _subfiles/intro-to-survival-analysis/_sec-greenwood.qmd >}}
+
+{{< slidebreak >}}
+
 :::{#exm-bmt}
 #### Bone Marrow Transplant Data
 


### PR DESCRIPTION
## Summary

Fixes the Quarto Publish failure that started on `main` after [d-morrison/rme#762](https://github.com/d-morrison/rme/pull/762) merged. CI's `quarto-actions/setup@HEAD` upgraded to Quarto 1.9.37, which added a stricter "no nested callouts" check ([failing run](https://github.com/d-morrison/rme/actions/runs/26154418173/job/76929922040)). The structure that newly trips it:

- `chapters/intro-to-survival-analysis.qmd:85` opens `:::{#exm-bmt}` and includes `_subfiles/intro-to-survival-analysis/_sec-surv-exm-bmt.qmd`,
- that subfile contains `::::{#thm-greenwood}` at its line 55,

so the rendered AST is a callout (the `exm`) containing another callout (the `thm`). PR [d-morrison/rme#762](https://github.com/d-morrison/rme/pull/762)'s callouty-theorem.lua change for `override-title: true` exms wraps the raw block content directly, surfacing this nesting that older Quarto silently accepted.

## Approach (option 1 of three I previously outlined)

Restructured the source so Greenwood's theorem lives outside the example:

- **New subfile** `_subfiles/intro-to-survival-analysis/_sec-greenwood.qmd` carries the KM survival-function formula, `:::{#thm-greenwood}` (Greenwood's variance estimator with the existing `#eq-var-est-surv` label), and the optional "Understanding Greenwood's formula" derivation.
- **Removed** those same blocks from `_sec-surv-exm-bmt.qmd`. The example's KM-curves subsection now opens with a one-line back-reference to `@thm-greenwood`, preserving narrative continuity.
- **New chapter section** "Greenwood's formula for the variance of the KM estimator" inserted between the log-rank test section and the `:::{#exm-bmt}` div in `chapters/intro-to-survival-analysis.qmd`.

Cross-reference labels (`@thm-greenwood`, `@eq-var-est-surv`) are preserved verbatim, so any in-text references continue to resolve.

## Verification

I expanded the chapter's `{{< include >}}` directives inline and walked the AST for theorem-type divs nested inside other theorem-type divs. The pre-fix tree had `#exm-bmt > #thm-greenwood`; the post-fix tree has zero such nestings.

```
$ python3 walk_nested_callouts.py chapters/intro-to-survival-analysis.qmd
No nested callouts (theorem-types) found in expanded chapter ✓
```

Pre-commit checks (render + lint on the two changed subfiles + spell-check) all clean on Quarto 1.9.36 locally. The CI failure was specific to 1.9.37's stricter check, which this structure avoids by construction.

## Test plan

- [ ] Confirm `quarto render` on `main` after merge (Quarto 1.9.37 via `setup@HEAD`).
- [ ] Spot-check the rendered chapter to confirm narrative flow still reads naturally with the theorem hoisted into its own section before the BMT example.
- [ ] Verify `@thm-greenwood` and `@eq-var-est-surv` cross-references still resolve in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)