### PR TITLE
Fix nested-callout regression breaking Quarto Publish on main

### DIFF
--- a/_subfiles/intro-to-survival-analysis/_sec-US-hazards.qmd
+++ b/_subfiles/intro-to-survival-analysis/_sec-US-hazards.qmd
@@ -74,12 +74,6 @@ Daily Hazard Rates in 2004 for US Males and Females 1-40
 
 {{< slidebreak >}}
 
-:::{#exr-compare-mf}
-Why do the male and female hazard functions in @fig-haz-mf differ where they do?
-:::
-
-{{< slidebreak >}}
-
 ::: {#fig-surv-US-females}
 
 ```{r}
@@ -97,11 +91,5 @@ plot(age2, exp(-cs2), type = "l", lwd = 2, xlab = "Age", ylab = "Survival")
 
 Survival Curve in 2004 for US Females
 
-:::
-
-{{< slidebreak >}}
-
-:::{#exr-surv-vs-haz}
-Compare and contrast @fig-surv-US-females with @fig-haz-female-US.
 :::
 

--- a/_subfiles/intro-to-survival-analysis/_sec-surv-dists.qmd
+++ b/_subfiles/intro-to-survival-analysis/_sec-surv-dists.qmd
@@ -33,6 +33,18 @@
 
 {{< slidebreak >}}
 
+:::{#exr-compare-mf}
+Why do the male and female hazard functions in @fig-haz-mf differ where they do?
+:::
+
+{{< slidebreak >}}
+
+:::{#exr-surv-vs-haz}
+Compare and contrast @fig-surv-US-females with @fig-haz-female-US.
+:::
+
+{{< slidebreak >}}
+
 ## The Cumulative Hazard Function
 
 {{< include _subfiles/intro-to-survival-analysis/_sec-cuhaz.qmd >}}


### PR DESCRIPTION
## Summary

- Quarto Publish on main has been failing since the Quarto strict nested-callout check tightened. The failure is in `chapters/intro-to-survival-analysis.qmd`: `:::{#exm-us-time-to-death-2004}` (defined in `_sec-surv-dists.qmd`) wraps an include of `_sec-US-hazards.qmd`, which itself opens two `:::{#exr-...}` callouts — nested-callout error.
- Same fix pattern as [d-morrison/rme#780](https://github.com/d-morrison/rme/pull/780) (which lifted `#thm-greenwood` out of `#exm-bmt`): lift the two `:::{#exr-...}` blocks out of the example.

## Changes

- `_subfiles/intro-to-survival-analysis/_sec-US-hazards.qmd`: drop `:::{#exr-compare-mf}` and `:::{#exr-surv-vs-haz}` (keep all three figures).
- `_subfiles/intro-to-survival-analysis/_sec-surv-dists.qmd`: add those two exercises after the `:::{#exm-us-time-to-death-2004}` div closes.

## Verification

- Cross-references (`@fig-haz-mf`, `@fig-surv-US-females`, `@fig-haz-female-US`) still resolve — the figures remain in the included subfile.
- `quarto render chapters/intro-to-survival-analysis.qmd --to html` passes locally on Quarto 1.9.36.
- The strict-check Quarto on the runner (Quarto 1.10.x) will now find no nested callouts in this chapter; the failure path in [run 26202032378](https://github.com/d-morrison/rme/actions/runs/26202032378) was specifically the `#exr-*` inside `#exm-us-time-to-death-2004`.

## Test plan

- [ ] CI Quarto-Publish-style render passes on this branch
- [ ] After merge, the next push to `main` succeeds in Quarto Publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)