### PR TITLE
Fix PDF double-superscript error breaking Quarto Publish on main

### DIFF
--- a/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
@@ -219,7 +219,7 @@ $$
 &\eqdef \loghaz(t|\vx) - \loghaz(t|\vxs)
 \\
 &=\eta(\vx)-\eta(\vxs)\\
-&= \vx'\vb-\vxs'\vb\\
+&= \vx'\vb-\paren{\vxs}'\vb\\
 &= (\vx - \vxs)'\vb
 \ea
 $$


### PR DESCRIPTION
## Summary

The Quarto Publish workflow on `main` has been failing in the lualatex PDF build with `Double superscript.` at proportional-hazards-models line 2744 since [d-morrison/rme#759](https://github.com/d-morrison/rme/pull/759) merged. See failing job: [run 26209078406 job 77115424688](https://github.com/d-morrison/rme/actions/runs/26209078406/job/77115424688).

```
l.2744 ...ilde{x}'\tilde{\beta}-{\tilde{x}^*}'\tilde
                                                  {\beta}\\
```

The source expression introduced by #759's notation refactor is:

```latex
&= \vx'\vb-\vxs'\vb\\
```

`\vxs` is defined in `latex-macros/macros.qmd` as `{\vec{x}^*}`, so `\vxs'` expands to `{\tilde{x}^*}'`. Recent `unicode-math` flags a prime token immediately after a group that itself ends in a superscript as "double superscript", even when the brace nominally separates them — both `^*` and `^\prime` land in the same `\__um_superscript:n` scope.

HTML/MathJax accepts the expression, so this only surfaces in the lualatex PDF path on `main` (and HTML preview builds keep passing — that's why it slipped past PR #759's preview).

## Fix

Wrap `\vxs` in `\paren{...}` on the offending line (one site, `_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd:222`):

```diff
 &=\eta(\vx)-\eta(\vxs)\\
-&= \vx'\vb-\vxs'\vb\\
+&= \vx'\vb-\paren{\vxs}'\vb\\
 &= (\vx - \vxs)'\vb
```

`\paren{}` inserts `\left(...\right)`, so the outer group ends with `\right)` instead of `^*`. The other `\vxs` uses in the chapter are already either inside `\paren{}`, inside `\tp{(...)}` (literal parens), or terminate cleanly — no other lines need changing.

## Verification

- `quarto render chapters/proportional-hazards-models.qmd --to html` passes locally.
- The expression now matches the conventional notation for transpose of a starred vector (parens around the decorated symbol).
- The next CI run on this branch will exercise the full lualatex PDF path and confirm the fix on the runner.

## Test plan

- [ ] CI build-deploy passes on this branch (lualatex + tlmgr update + PDF render)
- [ ] After merge, the next push to `main` succeeds in Quarto Publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)