### PR TITLE
Fix git push auth in @claude issue-trigger post-step (follow-up to #788)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -496,7 +496,21 @@ jobs:
             exit 0
           fi
           echo "Pushing $BRANCH ($STARTING_SHA -> $CURRENT_SHA)"
-          git push origin "$BRANCH"
+          # Push to an explicit token-bearing URL rather than `origin`.
+          # The "Checkout submodules" step earlier in this job sets a
+          # global `url.https://x-access-token:${SUBMODULES_TOKEN}@github.com/.insteadOf
+          # https://github.com/` rule so submodule clones authenticate
+          # with SUBMODULES_TOKEN (a fine-grained PAT scoped to the
+          # submodule repos, not this one). That rule also rewrites
+          # `git push origin`'s resolved URL — sending the main-repo
+          # push under SUBMODULES_TOKEN, which has no write access here
+          # and produces "Authentication failed" (see run #26313620971,
+          # the first real-world test of this post-step). The URL
+          # below starts with `https://x-access-token:...@github.com/`,
+          # which doesn't match the rewrite pattern (`https://github.com/`),
+          # so it passes through and reaches the remote under
+          # GITHUB_TOKEN — which has `contents: write` for this repo.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
           # Reuse an existing open PR for this branch if one is somehow
           # already present (idempotent re-run safety); otherwise open.
           EXISTING=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')


### PR DESCRIPTION
## Summary

PR #788 added a `Push branch and open draft PR for issue trigger` post-step to `.github/workflows/claude.yml`. First real-world run (workflow run #26313620971 on issue #790, triggered immediately after #788 merged) failed at `git push`:

```
Pushing claude/issue-790-20260522-215023 (c37823e -> c843f22)
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/d-morrison/rme.git/'
```

## Root cause

The earlier `Checkout submodules` step in the same workflow sets a `--global` git config:

```
git config --global url."https://x-access-token:${SUBMODULES_TOKEN}@github.com/".insteadOf "https://github.com/"
```

This rewrites all `https://github.com/...` URLs to authenticate with `SUBMODULES_TOKEN` (a fine-grained PAT scoped to the submodule repos, not this one). When `git push origin "$BRANCH"` resolves `origin` to `https://github.com/d-morrison/rme`, the rule rewrites it to `https://x-access-token:<SUBMODULES_TOKEN>@github.com/d-morrison/rme` and the push goes out under a token with no write access → 403.

## Fix

Push to an explicit `https://x-access-token:${GH_TOKEN}@github.com/...` URL. That URL starts with `https://x-access-token:` (not with `https://github.com/`), so it doesn't match the rewrite pattern and reaches the remote under `GITHUB_TOKEN`, which has the `contents: write` scope this job needs.

Same pattern the action's tag-mode `git-push.sh` uses internally; the agent-mode replacement I added in #788 just didn't replicate it.

## Test plan

- [ ] Trigger `@claude` on a fresh test issue, verify a `claude/issue-N-<timestamp>` branch is pushed without auth failure
- [ ] Verify the draft PR opens against the right base
- [ ] Verify a no-op session (Claude makes no commits) still exits the step cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)