### PR TITLE
claude-code-review.yml: fire on human pushes to bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,10 +33,14 @@ jobs:
   claude-review:
     # workflow_dispatch is only fired by claude.yml after it pushed commits,
     # so we always want to run in that case; otherwise apply the usual
-    # bot-actor filter to skip Dependabot/Copilot/etc. PRs.
+    # bot-actor filter — but only on the *push* side. A human pushing a
+    # commit to a bot-authored PR (Dependabot/Copilot/anthropic-code-agent
+    # etc.) should still get a review fired; without this, those PRs are
+    # stuck on whatever verdict was generated when they were first opened.
+    # See d-morrison/rme#801 for the original symptom report.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.user.type != 'Bot' && github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))
+      (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
Closes [d-morrison/rme#801](https://github.com/d-morrison/rme/issues/801).

## Why

The previous filter:

\`\`\`yaml
if: >
  github.event_name == 'workflow_dispatch' ||
  (github.event.pull_request.user.type != 'Bot' && github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))
\`\`\`

required **all three** of \`pull_request.user.type != 'Bot'\` (the PR's *author*), \`sender.type != 'Bot'\`, and \`!endsWith(actor, '[bot]')\`. The PR-author clause meant any PR opened by a bot (Copilot, anthropic-code-agent, Dependabot, etc.) could never get a fresh auto-review on subsequent pushes, even when the pushing actor was me.

That stranded [d-morrison/rme#706](https://github.com/d-morrison/rme/pull/706) and [d-morrison/rme#381](https://github.com/d-morrison/rme/pull/381) on stale verdicts from when they were first opened, with no working path to a fresh review:

- The \`synchronize\` event was silently skipped by this filter (logged as \`completed:skipped\` runs).
- The \`workflow_dispatch\` fallback from \`claude.yml\` errors out in \`anthropics/claude-code-action\` because \`track_progress: true\` isn't supported for that event type (the action explicitly enumerates the allowed events).

## What

Drop the PR-author check. The remaining \`sender.type != 'Bot' && !endsWith(actor, '[bot]')\` checks still guard against bot-driven loops (a bot pushing commits as itself is still filtered out — \`actor\` is the entity making the API call), but a human pushing a fix to a bot's PR now correctly fires the review.

## Test plan

- [ ] After merge, push a small change to [d-morrison/rme#706](https://github.com/d-morrison/rme/pull/706) (anthropic-code-agent-authored) and confirm Claude Code Review fires
- [ ] Same for [d-morrison/rme#381](https://github.com/d-morrison/rme/pull/381) (Copilot-authored)
- [ ] Verify Dependabot PRs (if any open) don't fire on Dependabot's own pushes — actor would be \`dependabot[bot]\`, still filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)