### PR TITLE
Expose EPI204_TOKEN for ucdavis/epi204 read access in @claude flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -659,6 +659,31 @@ The token is loaded automatically for the Copilot coding agent (via the
 `copilot` deployment environment) and for `@claude` PR sessions (via a
 job-level `env:` mapping in `.github/workflows/claude.yml`).
 
+## Accessing the private `ucdavis/epi204` repository
+
+The `EPI204_TOKEN` environment variable holds a fine-grained PAT with
+read access to `https://github.com/ucdavis/epi204` (Epi 204 homework
+and solutions for this course). Use it on demand when you need to look
+up homework or solution content from that repo. If `EPI204_TOKEN` is
+empty in your environment, the repo is not available for this session —
+say so rather than guessing.
+
+```bash
+# Clone the whole repo:
+git clone "https://x-access-token:${EPI204_TOKEN}@github.com/ucdavis/epi204.git" /tmp/epi204
+
+# Fetch a specific file via the API:
+curl -fsSL -H "Authorization: token ${EPI204_TOKEN}" \
+  https://raw.githubusercontent.com/ucdavis/epi204/main/path/to/file.qmd
+
+# Hit the GitHub REST API:
+GH_TOKEN="${EPI204_TOKEN}" gh api repos/ucdavis/epi204/contents/path/to/file.qmd
+```
+
+The token is loaded automatically for the Copilot coding agent (via the
+`copilot` deployment environment) and for `@claude` PR sessions (via a
+job-level `env:` mapping in `.github/workflows/claude.yml`).
+
 ## Color Coding Strategy for Math Expressions
 
 Use `\red{...}` and `\blue{...}` purposefully and consistently to help readers:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,13 +58,15 @@ jobs:
       issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
-    # Expose the ucdavis/epi202 fine-grained PAT to every step in this job,
-    # including the Claude action's subprocess. See .github/copilot-instructions.md
-    # ("Accessing the private ucdavis/epi202 repository") for usage. Empty if
-    # the secret isn't set, in which case the variable is simply unavailable
-    # to Claude — no error.
+    # Expose the ucdavis/epi202 and ucdavis/epi204 fine-grained PATs to
+    # every step in this job, including the Claude action's subprocess.
+    # See .github/copilot-instructions.md ("Accessing the private
+    # ucdavis/epi202 repository" and "Accessing the private ucdavis/epi204
+    # repository") for usage. Empty if the secret isn't set, in which case
+    # the variable is simply unavailable to Claude — no error.
     env:
       EPI202_TOKEN: ${{ secrets.EPI202_TOKEN }}
+      EPI204_TOKEN: ${{ secrets.EPI204_TOKEN }}
 
     steps:
       # Post a visible acknowledgment on the triggering PR/issue BEFORE the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,10 @@ If a failure is not caused by your changes, document it in the PR description.
   `.github/copilot-instructions.md` → "Accessing the private
   `ucdavis/epi202` repository" for usage snippets. If the variable is
   empty, the repo is unavailable for this session.
+
+- `$EPI204_TOKEN` — fine-grained PAT with read access to
+  `https://github.com/ucdavis/epi204` (Epi 204 homework and solutions).
+  Use on demand to look up homework/solution content from that repo;
+  see `.github/copilot-instructions.md` → "Accessing the private
+  `ucdavis/epi204` repository" for usage snippets. If the variable is
+  empty, the repo is unavailable for this session.


### PR DESCRIPTION
## Summary

The repo already wires up `EPI202_TOKEN` for read access to `ucdavis/epi202` (Epi 202 course materials, taught alongside this Epi 204 course). Add a parallel `EPI204_TOKEN` for read access to `ucdavis/epi204` (this course's homework and solutions) so `@claude` sessions can look up that content on demand.

Mirrors the existing `EPI202_TOKEN` setup in three places:

- `.github/workflows/claude.yml` — job-level `env:` exposes the secret to every step (incl. the Claude action's subprocess)
- `.github/copilot-instructions.md` — new "Accessing the private `ucdavis/epi204` repository" section with the same clone / raw-fetch / `gh api` snippets as the epi202 section
- `CLAUDE.md` → External Resources Available in This Session — new bullet pointing at the usage docs

Kept as a separate token alongside `EPI202_TOKEN` (rather than consolidating, even though the new PAT happens to grant access to both repos) so each can be rotated/revoked independently.

## Test plan

- [ ] Verify the `EPI204_TOKEN` secret is set on `d-morrison/rme` (already done by user)
- [ ] Trigger `@claude` on a test issue and verify it can `curl -fsSL -H "Authorization: token ${EPI204_TOKEN}" https://raw.githubusercontent.com/ucdavis/epi204/main/README.md` (or similar) successfully
- [ ] Verify `EPI202_TOKEN` still works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)