### PR TITLE
Post Claude's response back to thread when @claude session produces prose, not commits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -484,7 +484,19 @@ jobs:
       # Claude's running text on top would be noise — skipped via
       # the COMMITTED check below.
       - name: Post Claude's response if no code was committed
-        if: always() && steps.claude.outcome == 'success'
+        # Skip on `@claude review` triggers — the dispatch step below
+        # will fire claude-code-review.yml, which posts its own
+        # sticky review comment. Posting Claude's agent-session prose
+        # on top would double-comment the PR (the agent's internal
+        # "I'll review this PR" monologue, then the real review).
+        # Predicate MUST stay in sync with the dispatch step's `if:`.
+        if: |
+          always() &&
+          steps.claude.outcome == 'success' &&
+          !(
+            contains(github.event.comment.body, '@claude review') ||
+            contains(github.event.review.body, '@claude review')
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENTITY_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
@@ -549,14 +561,26 @@ jobs:
             exit 0
           fi
 
-          # GitHub comment bodies are capped at 65,536 characters.
-          # Truncate with a link back to the full run output if we're
-          # over a safe ceiling (60k leaves headroom for the footer).
+          # GitHub comment bodies are capped at 65,536 *bytes* in the
+          # stored value, so truncate by bytes (not characters). 60k
+          # leaves ~5.5k headroom for the footer.
+          #
+          # Why `head -c` over bash `${var:0:N}`: bash substring
+          # expansion is character-based under UTF-8 locales, so 60000
+          # multibyte chars could exceed the 65,536-byte cap and the
+          # `gh issue comment` call would 422 with no truncation
+          # actually happening. `head -c` is strictly byte-based.
+          # Caveat: a byte cut may slice the final character mid-
+          # codepoint, producing a garbled trailing byte sequence
+          # right before the footer. That's acceptable for a corner
+          # case (responses >60k bytes are rare); the footer still
+          # renders and the full text is one click away in the
+          # workflow run log.
           MAX_LEN=60000
           if [ "${#RESPONSE}" -gt "$MAX_LEN" ]; then
-            RESPONSE="${RESPONSE:0:$MAX_LEN}
+            RESPONSE="$(printf '%s' "$RESPONSE" | head -c "$MAX_LEN")
 
-          … (response truncated at ${MAX_LEN} chars; full text in the [workflow run](${RUN_URL}))"
+          … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"
           fi
 
           # `gh issue comment` works for both issues and PRs (both

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -325,6 +325,19 @@ jobs:
             ${{ github.event_name }}. Address the request in that
             comment/issue/review.
 
+            **If your reply is prose (a question answered, a
+            recommendation, a design discussion) rather than a code
+            change**, write your final assistant message as if you
+            were posting a reply on the triggering PR/issue thread —
+            because that's what happens: a post-Claude workflow step
+            takes your last assistant message and posts it back to
+            the source thread when you didn't commit any code. (When
+            you DO commit code, the commits themselves are the
+            deliverable and the post-step skips posting your text to
+            avoid noise.) Don't write it as an internal log
+            ("Investigated foo, found bar, will do baz") — write it
+            as the actual reply you want the requester to read.
+
             **Before declaring the task complete, check for additional
             @claude requests that arrived after the triggering event.**
 
@@ -445,6 +458,113 @@ jobs:
           # gh CLI for the polling step in the prompt above, plus WebFetch
           # for every host in the shared stats-allowlist.
           claude_args: '--allowed-tools "${{ steps.tools.outputs.allowed }}"'
+
+      # Post Claude's final assistant message back to the source thread
+      # when no code was committed.
+      #
+      # Background: claude-code-action runs in `agent` mode whenever
+      # `prompt:` is set (we set it for the late-comment polling loop
+      # above). Agent mode skips the action's built-in machinery that
+      # tag mode uses to surface Claude's final response as a sticky
+      # GitHub comment — the action just runs the agent and assumes
+      # the workflow author handles output surfacing. We already added
+      # explicit pre/post steps for the analogous setup-branch +
+      # git-push gap (#788 / #794); this step closes the remaining
+      # gap for **prose** responses, where Claude's deliverable is
+      # text rather than commits and there's nothing else to surface.
+      # See PR #755 comment 4530859000 (2026-05-25): a math question
+      # ran a successful 60s / 16-turn Claude session that produced
+      # ~$0.19 of thinking and zero visible output, because the
+      # response lived in /home/runner/work/_temp/claude-execution-output.json
+      # until the runner tore down.
+      #
+      # When Claude HAS committed code, the commits themselves convey
+      # the work and the existing `Re-request review` / `Push branch
+      # and open draft PR` steps surface it; in that case posting
+      # Claude's running text on top would be noise — skipped via
+      # the COMMITTED check below.
+      - name: Post Claude's response if no code was committed
+        if: always() && steps.claude.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENTITY_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          ISSUE_BRANCH_STARTING_SHA: ${{ steps.issue_branch.outputs.starting_sha }}
+          PR_HEAD_BEFORE: ${{ steps.head_before.outputs.sha }}
+        run: |
+          # Did Claude commit anything? Two cases:
+          #   - Issue triggers: the pre-step put us on a fresh
+          #     `claude/issue-N-*` branch and recorded its tip in
+          #     ISSUE_BRANCH_STARTING_SHA. Local HEAD vs. that SHA
+          #     tells us whether Claude committed.
+          #   - PR triggers: PR_HEAD_BEFORE captured the PR's remote
+          #     head SHA pre-Claude. We re-fetch the remote head now;
+          #     if it moved, Claude pushed. (Local HEAD is `main` on
+          #     PR triggers — actions/checkout pulls the default
+          #     branch for `issue_comment` events — so the local-SHA
+          #     check from the issue branch doesn't apply here.)
+          COMMITTED=false
+          if [ -n "$ISSUE_BRANCH_STARTING_SHA" ]; then
+            CURRENT_LOCAL=$(git rev-parse HEAD)
+            if [ "$CURRENT_LOCAL" != "$ISSUE_BRANCH_STARTING_SHA" ]; then
+              COMMITTED=true
+            fi
+          fi
+          if [ -n "$PR_HEAD_BEFORE" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+            CURRENT_REMOTE=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+            if [ "$CURRENT_REMOTE" != "$PR_HEAD_BEFORE" ]; then
+              COMMITTED=true
+            fi
+          fi
+          if [ "$COMMITTED" = "true" ]; then
+            echo "Claude committed code; commits are the deliverable, skipping response-text post."
+            exit 0
+          fi
+
+          # Locate the execution-output JSON. Prefer the action's
+          # exported step output; fall back to the known default path
+          # in case the action version changes the output name.
+          FILE="${EXECUTION_FILE:-/home/runner/work/_temp/claude-execution-output.json}"
+          if [ ! -f "$FILE" ]; then
+            echo "::warning::No Claude execution output found at $FILE; nothing to post."
+            exit 0
+          fi
+
+          # The action streams one JSON event per line (NDJSON).
+          # Grab the LAST assistant message's text-typed content blocks
+          # (a single message may interleave text and tool_use blocks;
+          # we want only the prose).
+          RESPONSE=$(jq -rs '
+            [.[] | select(.type == "assistant")]
+            | last
+            | (.message.content // [])
+            | map(select(.type == "text") | .text)
+            | join("\n\n")
+          ' < "$FILE")
+
+          if [ -z "$RESPONSE" ] || [ "$RESPONSE" = "null" ]; then
+            echo "::warning::No assistant text in execution output; nothing to post."
+            exit 0
+          fi
+
+          # GitHub comment bodies are capped at 65,536 characters.
+          # Truncate with a link back to the full run output if we're
+          # over a safe ceiling (60k leaves headroom for the footer).
+          MAX_LEN=60000
+          if [ "${#RESPONSE}" -gt "$MAX_LEN" ]; then
+            RESPONSE="${RESPONSE:0:$MAX_LEN}
+
+          … (response truncated at ${MAX_LEN} chars; full text in the [workflow run](${RUN_URL}))"
+          fi
+
+          # `gh issue comment` works for both issues and PRs (both
+          # post to the same `/repos/{owner}/{repo}/issues/{N}/comments`
+          # endpoint internally), so we don't need to branch on
+          # PR-vs-issue here.
+          gh issue comment "$ENTITY_NUMBER" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
+            || echo "::warning::Could not post Claude's response back to the source thread."
 
       - name: Re-request review and dispatch code review if Claude pushed commits
         if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -459,6 +459,23 @@ jobs:
           # for every host in the shared stats-allowlist.
           claude_args: '--allowed-tools "${{ steps.tools.outputs.allowed }}"'
 
+      # Fetch the PR's head SHA once, post-Claude, for the two
+      # downstream steps that both need it: the prose-post step's
+      # COMMITTED check and the "Re-request review" step's
+      # SHA_AFTER comparison. Without this shared step each would
+      # call `gh api pulls/$N` independently — two round-trips per
+      # PR-trigger run where one suffices. PR-context only (mirrors
+      # the "Capture PR head SHA before Claude" step above).
+      - name: Capture PR head SHA after Claude
+        id: head_after
+        if: always() && (github.event.pull_request.number || github.event.issue.pull_request)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
       # Post Claude's final assistant message back to the source thread
       # when no code was committed.
       #
@@ -521,6 +538,7 @@ jobs:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
           ISSUE_BRANCH_STARTING_SHA: ${{ steps.issue_branch.outputs.starting_sha }}
           PR_HEAD_BEFORE: ${{ steps.head_before.outputs.sha }}
+          PR_HEAD_AFTER: ${{ steps.head_after.outputs.sha }}
         run: |
           # Did Claude commit anything? Two cases:
           #   - Issue triggers: the pre-step put us on a fresh
@@ -528,11 +546,13 @@ jobs:
           #     ISSUE_BRANCH_STARTING_SHA. Local HEAD vs. that SHA
           #     tells us whether Claude committed.
           #   - PR triggers: PR_HEAD_BEFORE captured the PR's remote
-          #     head SHA pre-Claude. We re-fetch the remote head now;
-          #     if it moved, Claude pushed. (Local HEAD is `main` on
-          #     PR triggers — actions/checkout pulls the default
-          #     branch for `issue_comment` events — so the local-SHA
-          #     check from the issue branch doesn't apply here.)
+          #     head SHA pre-Claude; PR_HEAD_AFTER (from the shared
+          #     "Capture PR head SHA after Claude" step) is the head
+          #     now. If they differ, Claude pushed. (Local HEAD is
+          #     `main` on PR triggers — actions/checkout pulls the
+          #     default branch for `issue_comment` events — so the
+          #     local-SHA check from the issue branch doesn't apply
+          #     here.)
           COMMITTED=false
           if [ -n "$ISSUE_BRANCH_STARTING_SHA" ]; then
             CURRENT_LOCAL=$(git rev-parse HEAD)
@@ -540,12 +560,8 @@ jobs:
               COMMITTED=true
             fi
           fi
-          if [ -n "$PR_HEAD_BEFORE" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
-            CURRENT_REMOTE=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
-            if [ "$CURRENT_REMOTE" != "$PR_HEAD_BEFORE" ]; then
-              COMMITTED=true
-            fi
+          if [ -n "$PR_HEAD_BEFORE" ] && [ "$PR_HEAD_AFTER" != "$PR_HEAD_BEFORE" ]; then
+            COMMITTED=true
           fi
           if [ "$COMMITTED" = "true" ]; then
             echo "Claude committed code; commits are the deliverable, skipping response-text post."
@@ -562,6 +578,18 @@ jobs:
           fi
 
           # The action streams one JSON event per line (NDJSON).
+          # First, sanity-check that the file actually contains
+          # `assistant`-typed events. If it doesn't, the most likely
+          # cause is an upstream schema change (the action renaming
+          # the event type), not a genuinely empty session — and the
+          # downstream jq below would silently yield "" and we'd post
+          # nothing with no clue why. Surface that case distinctly.
+          ASSISTANT_COUNT=$(jq -rs '[.[] | select(.type == "assistant")] | length' < "$FILE")
+          if [ "$ASSISTANT_COUNT" = "0" ]; then
+            echo "::warning::No assistant-typed events in $FILE — the action's output schema may have changed (expected .type == \"assistant\"). Nothing to post."
+            exit 0
+          fi
+
           # Grab the LAST assistant message's text-typed content blocks
           # (a single message may interleave text and tool_use blocks;
           # we want only the prose).
@@ -574,7 +602,7 @@ jobs:
           ' < "$FILE")
 
           if [ -z "$RESPONSE" ] || [ "$RESPONSE" = "null" ]; then
-            echo "::warning::No assistant text in execution output; nothing to post."
+            echo "::warning::Assistant events present but no text content; nothing to post."
             exit 0
           fi
 
@@ -639,6 +667,21 @@ jobs:
       # `@claude review` comment also produces commits; the
       # reviewer's own concurrency group cancels the duplicate so
       # only the freshest diff is reviewed.
+      #
+      # `contains()` is a SUBSTRING match (not word-boundary): bodies
+      # like `@claude review again` or `@claude reviewer` also match.
+      # That's intentionally lenient — the cost of a spurious match is
+      # one extra reviewer run, which the reviewer's concurrency group
+      # cancels. Do NOT tighten this to `startsWith` or a word-boundary
+      # check without re-checking the paired skip-predicate on the
+      # prose-post step above, which must stay in sync.
+      #
+      # No `steps.claude.outcome == 'success'` guard here (unlike the
+      # prose-post step): a review dispatch doesn't depend on the
+      # agent session's output, so we want it to fire on `@claude
+      # review` even if the agent step was skipped or cancelled
+      # (e.g., a concurrency cancellation). The reviewer reviews the
+      # PR's current diff regardless of what the agent run did.
       - name: Dispatch claude-code-review.yml on @claude review comment
         if: |
           always() &&
@@ -660,9 +703,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA_BEFORE: ${{ steps.head_before.outputs.sha }}
+          # Reuse the SHA already fetched by "Capture PR head SHA after
+          # Claude" rather than calling `gh api pulls/$N` a second time.
+          SHA_AFTER: ${{ steps.head_after.outputs.sha }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
-          SHA_AFTER=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
           echo "before=$SHA_BEFORE  after=$SHA_AFTER"
           if [ "$SHA_AFTER" != "$SHA_BEFORE" ]; then
             echo "Claude pushed new commits; re-requesting review and dispatching code review."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -484,18 +484,35 @@ jobs:
       # Claude's running text on top would be noise — skipped via
       # the COMMITTED check below.
       - name: Post Claude's response if no code was committed
-        # Skip on `@claude review` triggers — the dispatch step below
-        # will fire claude-code-review.yml, which posts its own
-        # sticky review comment. Posting Claude's agent-session prose
-        # on top would double-comment the PR (the agent's internal
-        # "I'll review this PR" monologue, then the real review).
-        # Predicate MUST stay in sync with the dispatch step's `if:`.
+        # Skip on `@claude review` triggers that have PR context — the
+        # dispatch step below will fire claude-code-review.yml, which
+        # posts its own sticky review comment. Posting Claude's
+        # agent-session prose on top would double-comment the PR
+        # (the agent's internal "I'll review this PR" monologue, then
+        # the real review).
+        #
+        # The PR-context guard (`pull_request.number || issue.pull_request`)
+        # is load-bearing: without it, `@claude review` on a plain
+        # *issue* would skip the prose-post AND skip the dispatch
+        # (which has its own PR-context guard), losing the response
+        # entirely — the exact bug this PR fixes, re-introduced for
+        # this one trigger pattern. With the guard, plain-issue
+        # triggers fall through to the prose-post regardless of body.
+        #
+        # The `@claude review` predicate MUST stay in sync with the
+        # dispatch step's `if:` predicate. Note: `contains()` is
+        # case-sensitive, so `@Claude review` would not match here
+        # (or in the dispatch step). Standard GitHub `@`-mentions
+        # are lowercase so this matches the common case.
         if: |
           always() &&
           steps.claude.outcome == 'success' &&
           !(
-            contains(github.event.comment.body, '@claude review') ||
-            contains(github.event.review.body, '@claude review')
+            (
+              contains(github.event.comment.body, '@claude review') ||
+              contains(github.event.review.body, '@claude review')
+            ) &&
+            (github.event.pull_request.number || github.event.issue.pull_request)
           )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -565,19 +582,25 @@ jobs:
           # stored value, so truncate by bytes (not characters). 60k
           # leaves ~5.5k headroom for the footer.
           #
-          # Why `head -c` over bash `${var:0:N}`: bash substring
-          # expansion is character-based under UTF-8 locales, so 60000
-          # multibyte chars could exceed the 65,536-byte cap and the
-          # `gh issue comment` call would 422 with no truncation
-          # actually happening. `head -c` is strictly byte-based.
+          # Both the guard AND the truncation are byte-based:
+          # - Guard: `wc -c` counts bytes. Bash's `${#var}` counts
+          #   characters under UTF-8 locales (the default on GitHub
+          #   runners), so a response with 30k Chinese characters
+          #   (~90k bytes) would not trip a 60k character guard,
+          #   and the truncation below would never fire — but the
+          #   subsequent `gh issue comment` would 422 on the
+          #   oversized body. Counting bytes here closes that hole.
+          # - Truncation: `head -c` is strictly byte-based, so the
+          #   cut respects the 65,536-byte cap.
           # Caveat: a byte cut may slice the final character mid-
           # codepoint, producing a garbled trailing byte sequence
-          # right before the footer. That's acceptable for a corner
-          # case (responses >60k bytes are rare); the footer still
+          # right before the footer. Acceptable for a corner case
+          # (responses >60k bytes are rare); the footer still
           # renders and the full text is one click away in the
           # workflow run log.
           MAX_LEN=60000
-          if [ "${#RESPONSE}" -gt "$MAX_LEN" ]; then
+          BYTE_LEN=$(printf '%s' "$RESPONSE" | wc -c)
+          if [ "$BYTE_LEN" -gt "$MAX_LEN" ]; then
             RESPONSE="$(printf '%s' "$RESPONSE" | head -c "$MAX_LEN")
 
           … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -566,6 +566,48 @@ jobs:
           gh issue comment "$ENTITY_NUMBER" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
             || echo "::warning::Could not post Claude's response back to the source thread."
 
+      # Dispatch the dedicated reviewer workflow when the triggering
+      # comment looks like an explicit review request.
+      #
+      # Background: `claude-code-review.yml` is the dedicated reviewer
+      # (sticky-comment + delete-prior-sticky pattern, inline review
+      # threads, etc.) and only triggers on `pull_request` events
+      # (opened/synchronize/ready_for_review/reopened) and explicit
+      # `workflow_dispatch`. `issue_comment` is NOT in its trigger
+      # list. So when a user types "@claude review" on a PR, the
+      # event fires *this* workflow (an agent-mode run that emits
+      # prose via the post-step above) rather than the reviewer.
+      # See PR #802 comment 4530845824 (2026-05-25): "@claude review"
+      # produced a 125s agent session with no visible review output
+      # — nothing was dispatched, nothing was posted.
+      #
+      # The earlier `Re-request review and dispatch code review if
+      # Claude pushed commits` step below dispatches the reviewer
+      # only when Claude pushes new commits — useful for the
+      # iterate-on-the-diff loop, but it doesn't cover the case where
+      # the user just wants a fresh review without code changing
+      # hands. This step closes that gap by dispatching the reviewer
+      # whenever the triggering comment body literally contains
+      # `@claude review`. Both paths can fire on the same run if a
+      # `@claude review` comment also produces commits; the
+      # reviewer's own concurrency group cancels the duplicate so
+      # only the freshest diff is reviewed.
+      - name: Dispatch claude-code-review.yml on @claude review comment
+        if: |
+          always() &&
+          (github.event.pull_request.number || github.event.issue.pull_request) &&
+          (
+            contains(github.event.comment.body, '@claude review') ||
+            contains(github.event.review.body, '@claude review')
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          echo "Dispatching claude-code-review.yml for PR #$PR_NUMBER (@claude review comment)."
+          gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" \
+            || echo "::warning::Could not dispatch claude-code-review.yml; review will not auto-run."
+
       - name: Re-request review and dispatch code review if Claude pushed commits
         if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''
         env:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -501,6 +501,15 @@ jobs:
       # Claude's running text on top would be noise — skipped via
       # the COMMITTED check below.
       - name: Post Claude's response if no code was committed
+        # The `steps.claude.outcome == 'success'` guard is deliberate:
+        # we only surface a *completed* session's response. A
+        # cancelled session (concurrency preemption — another run is
+        # taking over and will post its own response) or a timed-out
+        # one (partial, possibly-misleading output) is intentionally
+        # NOT posted. If surfacing partial output on cancellation
+        # ever proves useful, broaden to `!= 'skipped'` with a
+        # "(session interrupted)" footer.
+        #
         # Skip on `@claude review` triggers that have PR context — the
         # dispatch step below will fire claude-code-review.yml, which
         # posts its own sticky review comment. Posting Claude's
@@ -560,7 +569,15 @@ jobs:
               COMMITTED=true
             fi
           fi
-          if [ -n "$PR_HEAD_BEFORE" ] && [ "$PR_HEAD_AFTER" != "$PR_HEAD_BEFORE" ]; then
+          # Require a non-empty PR_HEAD_AFTER: if the "Capture PR head
+          # SHA after Claude" step's `gh api` failed (transient 5xx,
+          # rate limit), its output is "". Without the `-n` guard,
+          # "" != "$PR_HEAD_BEFORE" would be true and we'd wrongly
+          # conclude Claude committed and SKIP posting the prose —
+          # the exact data-loss this step exists to prevent. Defaulting
+          # to "not committed" on an unknown AFTER SHA errs toward
+          # posting (safe) rather than swallowing (lossy).
+          if [ -n "$PR_HEAD_BEFORE" ] && [ -n "$PR_HEAD_AFTER" ] && [ "$PR_HEAD_AFTER" != "$PR_HEAD_BEFORE" ]; then
             COMMITTED=true
           fi
           if [ "$COMMITTED" = "true" ]; then
@@ -709,7 +726,13 @@ jobs:
         run: |
           PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
           echo "before=$SHA_BEFORE  after=$SHA_AFTER"
-          if [ "$SHA_AFTER" != "$SHA_BEFORE" ]; then
+          # Require a non-empty SHA_AFTER: if "Capture PR head SHA
+          # after Claude" failed, its output is "" and a bare
+          # `"" != "$SHA_BEFORE"` would be true, dispatching a
+          # spurious review against an unchanged diff. Defaulting to
+          # "no new commits" on an unknown AFTER SHA errs toward not
+          # dispatching (cheap miss) rather than a wasted review run.
+          if [ -n "$SHA_AFTER" ] && [ "$SHA_AFTER" != "$SHA_BEFORE" ]; then
             echo "Claude pushed new commits; re-requesting review and dispatching code review."
             gh api -X POST \
               "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \


### PR DESCRIPTION
## Summary

Closes two related agent-mode gaps surfaced on 2026-05-25 — both downstream of the fact that `claude-code-action` in agent mode (always, when `prompt:` is set) doesn't run the response-surfacing or review-dispatching machinery that tag mode does. Same pattern as the setup-branch + git-push gap fixed in #788/#794.

### 1. PR #755 comment 4530845824 — prose response evaporates

A math question on PR #755 fired a successful 60s / 16-turn Claude session that produced ~$0.19 of thinking and **zero visible output**. The response lived in `/home/runner/work/_temp/claude-execution-output.json` until the runner tore down.

**Fix (commit `e90350bef`):** new post-step `Post Claude's response if no code was committed`. Reads `steps.claude.outputs.execution_file` (with fallback to the known default path), extracts the last assistant message's text content via `jq`, truncates to GitHub's 65,536-char comment ceiling, posts via `gh issue comment` (works for both PRs and issues — both hit `/repos/{owner}/{repo}/issues/{N}/comments` internally). Skipped when Claude committed code so the commits-as-deliverable case isn't duplicated by noise prose.

Also updated the prompt so Claude knows its final message will be posted on prose-only sessions, and writes for the requester audience rather than as an internal log.

### 2. PR #802 comment 4530845824 — `@claude review` produces no review

`claude-code-review.yml` (the dedicated reviewer with the sticky-comment + delete-prior-sticky pattern, inline review threads, etc.) triggers only on `pull_request` events and explicit `workflow_dispatch`. **`issue_comment` is not in its trigger list.** So `@claude review` on a PR fires the agent-mode `claude.yml` workflow, not the reviewer.

The existing `Re-request review and dispatch code review if Claude pushed commits` step in `claude.yml` only dispatches the reviewer when Claude pushed new commits — useful for the iterate-on-the-diff loop, but doesn't cover the case where the user just wants a fresh review without code changing hands.

**Fix (commit `f41c1d50d`):** new post-step `Dispatch claude-code-review.yml on @claude review comment`. Fires whenever the triggering comment body literally contains `@claude review` (covers all three event bodies: `issue_comment`, `pull_request_review`, `pull_request_review_comment`). Both this dispatch and the existing commit-driven dispatch can fire on the same run; the reviewer workflow's own concurrency group cancels the duplicate so only the freshest diff is reviewed.

## Test plan

- [ ] Verify YAML parses cleanly on GitHub
- [ ] Post `@claude what's 2+2?` on a test PR — verify a comment appears with Claude's response (commit 1)
- [ ] Trigger `@claude` with a request that produces a code change — verify the existing post-step posts (PR creation / re-request review) and the new prose post-step skips silently (commit 1, skip path)
- [ ] Post `@claude review` on a test PR — verify `claude-code-review.yml` is dispatched and produces a sticky review comment (commit 2)
- [ ] Verify the truncation kicks in cleanly if Claude's response exceeds 60k chars (synthetic test, low priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)