### PR TITLE
claude-code-review: unblock bot-authored PRs (fixes #801, option 1)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,12 +31,21 @@ concurrency:
 
 jobs:
   claude-review:
-    # workflow_dispatch is only fired by claude.yml after it pushed commits,
-    # so we always want to run in that case; otherwise apply the usual
-    # bot-actor filter to skip Dependabot/Copilot/etc. PRs.
+    # workflow_dispatch is fired by claude.yml after the @claude run
+    # pushed commits, or by the new "@claude review" dispatch path, so
+    # we always want to run in that case. Otherwise apply the
+    # bot-actor filter — but key it on who PUSHED (sender / actor),
+    # not who AUTHORED the PR. Bot-authored PRs (anthropic-code-agent,
+    # Copilot, etc.) iterated on by humans should get fresh reviews;
+    # the previous `pull_request.user.type != 'Bot'` clause blocked
+    # them indefinitely after the initial review, even when a human
+    # pushed a follow-up commit. See issue #801 (run 26350253996,
+    # PR #706: human-pushed commit to bot-authored PR was skipped).
+    # The sender/actor checks still cover bot-only loops on the push
+    # path (Dependabot autorebase, Copilot self-update, etc.).
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.user.type != 'Bot' && github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))
+      (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
Fixes #801 — option 1 only, per author direction.

## Summary

Drops `pull_request.user.type != 'Bot'` from the job's `if:` filter in `.github/workflows/claude-code-review.yml`, so bot-authored PRs (anthropic-code-agent, Copilot, etc.) get fresh reviews when a human pushes a follow-up commit.

The previous filter skipped any push to a PR whose **author** was a bot, even when a human pushed the iteration. Concrete case from #801: human-pushed commit `a272cc219` to PR #706 fired run id `26350253996` which completed `skipped`. PRs #706 and #381 (both bot-authored) were stuck on their initial reviews because of this.

The fix keys the bot-filter on **who pushed** (`sender.type` / `actor`), not **who authored the PR**. The sender/actor checks still cover the bot-only loop cases (Dependabot autorebase, Copilot self-update) without locking out human iteration on bot-opened PRs.

## Scope

This is **option 1** of the two fixes proposed in #801. Option 2 (conditional `track_progress` for `workflow_dispatch`) is **deferred** per #801's own note: *"Doing (1) is the bigger unblock — once the synchronize path works, the workflow_dispatch path matters much less."*

A separate PR can address option 2 later if/when the `workflow_dispatch` path failures become a real bottleneck.

## Test plan

- [ ] Verify YAML parses cleanly on GitHub
- [ ] Push a follow-up commit to a bot-authored PR (e.g., PR #706 or a fresh test PR opened by anthropic-code-agent) — verify the review fires instead of being skipped
- [ ] On a regular human-authored PR, push a commit — verify the review still fires unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)