### PR TITLE
Fix prose-post jq: execution_file is a single JSON array, not NDJSON

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -594,14 +594,30 @@ jobs:
             exit 0
           fi
 
-          # The action streams one JSON event per line (NDJSON).
-          # First, sanity-check that the file actually contains
-          # `assistant`-typed events. If it doesn't, the most likely
-          # cause is an upstream schema change (the action renaming
-          # the event type), not a genuinely empty session — and the
-          # downstream jq below would silently yield "" and we'd post
-          # nothing with no clue why. Surface that case distinctly.
-          ASSISTANT_COUNT=$(jq -rs '[.[] | select(.type == "assistant")] | length' < "$FILE")
+          # Extract the assistant events from the execution-output JSON.
+          #
+          # Format robustness: the action's execution_file is a single
+          # JSON array of event objects (`[{...},{...}]`), NOT
+          # newline-delimited JSON as an earlier version of this step
+          # assumed. With `jq -s` (slurp), a single-array file becomes
+          # `[[...]]`, so a bare `.[] | select(.type==...)` indexes the
+          # inner *array* with `.type` and dies with "Cannot index array
+          # with string" (see run 26417479726, the first real run of
+          # this step after #805 merged). `flatten(1)` collapses that
+          # outer wrap so we iterate event objects either way — and it
+          # also tolerates true NDJSON (slurps to a flat array,
+          # flatten is a no-op) and a stray array element. The
+          # `type=="object"` guard then skips any non-object entry
+          # before `.type` is accessed (jq's `and` short-circuits).
+          # The same `flatten(1) | select(type=="object" ...)` prelude
+          # is repeated in the RESPONSE filter below — keep them in sync.
+
+          # Sanity-check that the file actually contains assistant-typed
+          # events. If it doesn't, the likely cause is an upstream
+          # schema change (the action renaming the event type), not a
+          # genuinely empty session — surface that distinctly rather
+          # than silently posting nothing.
+          ASSISTANT_COUNT=$(jq -rs 'flatten(1) | [.[] | select(type == "object" and .type == "assistant")] | length' < "$FILE")
           if [ "$ASSISTANT_COUNT" = "0" ]; then
             echo "::warning::No assistant-typed events in $FILE — the action's output schema may have changed (expected .type == \"assistant\"). Nothing to post."
             exit 0
@@ -611,7 +627,8 @@ jobs:
           # (a single message may interleave text and tool_use blocks;
           # we want only the prose).
           RESPONSE=$(jq -rs '
-            [.[] | select(.type == "assistant")]
+            flatten(1)
+            | [.[] | select(type == "object" and .type == "assistant")]
             | last
             | (.message.content // [])
             | map(select(.type == "text") | .text)


### PR DESCRIPTION
## Summary

The `Post Claude's response if no code was committed` step (added in #805) failed on its **first real run** — workflow run [26417479726](https://github.com/d-morrison/rme/actions/runs/26417479726) on PR #779 ("GAM chapter"):

```
jq: error (at <stdin>:2298): Cannot index array with string "type"
##[error]Process completed with exit code 5.
```

## Root cause

The step assumed `claude-code-action`'s `execution_file` is NDJSON (one JSON object per line) and used `jq -rs` (slurp). But the file is a **single JSON array** of event objects. Under `-s`, a single-array file becomes `[[...]]`, so `.[] | select(.type==...)` indexes the *inner array* with `.type` → error.

The step never ran against real action output before #805 merged (the prose-only-PR path is uncommon), so the format assumption went untested until now.

## Fix

Prepend `flatten(1)` to both jq programs (`ASSISTANT_COUNT` and `RESPONSE`), collapsing the slurp-wrap so we iterate event objects regardless of shape:

- single array (real case) → `[[...]]` → flatten → `[...]` ✓
- true NDJSON → slurp → `[...]` → flatten is a no-op ✓
- stray array element → flattened in ✓

Plus a `type == "object"` guard before `.type` access so any non-object entry is skipped (jq's `and` short-circuits, so `.type` is never reached on non-objects).

Verified locally against all three shapes (single array, NDJSON, NDJSON-with-stray-array): correct count and correct multi-paragraph text extraction.

## Test plan

- [ ] Merge, then trigger `@claude <a question>` on a PR (prose-only, no commits) — verify Claude's response is posted as a comment instead of the step erroring
- [ ] Verify a commit-producing `@claude` run still skips the prose-post (COMMITTED path) without invoking jq

🤖 Generated with [Claude Code](https://claude.com/claude-code)