### PR TITLE
Commit shared .claude/settings.json permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh api repos/d-morrison/rme/*)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh run view *)",
+      "Bash(gh run list *)",
+      "Bash(quarto render *)",
+      "Bash(Rscript -e 'lintr::lint*)",
+      "Bash(Rscript -e 'spelling::spell_check_package()')"
+    ]
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -249,10 +249,16 @@ jobs:
           # HTTP-method filtering. The ultimate bound on what's
           # possible is `GITHUB_TOKEN`'s scopes (`contents: write`,
           # `pull-requests: write`, `issues: write`), not this
-          # allowlist. `Bash(gh pr view:*)` and `Bash(gh issue view:*)`
-          # are strict subsets (the CLI commands hit the same API
-          # internally), so they're omitted.
-          GH_TOOLS="Bash(gh api repos/${{ github.repository }}/*)"
+          # allowlist.
+          #
+          # The `gh pr/issue/run` read-only CLI patterns below mirror
+          # the committed `.claude/settings.json` allowlist so the CI
+          # agent and local sessions grant the same inspection commands
+          # (these CLI subcommands hit the same API as `gh api` but
+          # under different command strings, so the `gh api repos/*`
+          # entry alone doesn't cover them). Kept to `view`/`list`
+          # (read-only) — no `gh pr merge`/`close`/`edit` etc.
+          GH_TOOLS="Bash(gh api repos/${{ github.repository }}/*),Bash(gh pr view *),Bash(gh pr list *),Bash(gh issue view *),Bash(gh issue list *),Bash(gh run view *),Bash(gh run list *)"
           # Git commands Claude needs to commit work in agent mode.
           # In tag mode the action auto-injects these; in agent mode
           # (which we're in whenever `prompt:` is set) it doesn't, and

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@
 # Local editor and OS metadata
 .DS_Store
 .positai/
-.claude
+# Ignore everything under .claude/ (local session state,
+# settings.local.json, etc.) EXCEPT the shared, committed permission
+# allowlist in settings.json.
+.claude/*
+!.claude/settings.json
 /.luarc.json
 
 # Quarto and render artifacts


### PR DESCRIPTION
Fixes the request in [PR #779 comment](https://github.com/d-morrison/rme/pull/779#issuecomment-4536977528), where the `@claude` CI agent reported it couldn't create `.claude/settings.json` (Write blocked in CI) and proposed an allowlist to reduce permission prompts.

## Context

`@claude` runs have been hitting 12–24 permission denials each on read-only inspection commands and the project's mandatory pre-commit checks. `.claude/` was blanket-gitignored, so no shared allowlist existed.

Chose the "both mechanisms" approach: commit a shared `.claude/settings.json` (read by local sessions **and** the CI agent via `settingSources: [user, project, local]`) **and** mirror the patterns into the workflow's `--allowed-tools`.

## Changes

- **`.gitignore`** — was `.claude` (ignores everything). Narrowed to `.claude/*` + `!.claude/settings.json`, so the shared allowlist is tracked while local session state and `settings.local.json` stay ignored.
- **`.claude/settings.json`** (new) — allows: read-only `gh pr/issue/run view+list`, repo-scoped `gh api repos/d-morrison/rme/*`, and the three CLAUDE.md pre-commit checks (`quarto render`, `lintr::lint`, `spelling::spell_check_package`).
- **`claude.yml`** — mirror the same read-only `gh pr/issue/run view+list` patterns into the workflow allowlist so the CI grant doesn't rely solely on settingSources merging. (`Rscript` / `quarto` / `gh api repos/*` were already there.)

## Deviations from the bot's proposed list

- **`gh api` scoped to the repo** (`gh api repos/d-morrison/rme/*`) instead of the bare `gh api *` the bot proposed — the bot's own note flagged the wildcard as a mutation risk (it'd allow arbitrary cross-org POST/PATCH/DELETE).
- Kept all `gh` entries to `view`/`list` (read-only) — no `merge`/`close`/`edit`.

## Test plan

- [ ] Verify JSON + YAML parse (done locally)
- [ ] After merge, observe whether `permission_denials_count` drops on the next `@claude` run
- [ ] Confirm `settings.local.json` and other `.claude/` contents remain gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)