### PR TITLE
preview: cancel superseded in-progress runs (closes #812)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,7 +22,14 @@ on:
       - '*.scss'
       - 'latex-macros'
 
-concurrency: preview-${{ github.ref }}
+# Cancel an in-progress preview build when a newer commit on the same
+# ref supersedes it. Without `cancel-in-progress: true` the default is
+# `false`, so a fresh push QUEUES behind the stale run and the
+# up-to-date preview is delayed until the obsolete one finishes
+# (see issue #812: PR #755 waited on an out-of-date preview run).
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-deploy:


### PR DESCRIPTION
Closes #812.

## Summary

The preview workflow already had a concurrency group but was missing `cancel-in-progress`, which defaults to `false`. So a new push to a ref **queued** its preview build behind the in-flight (now-stale) one instead of cancelling it — delaying the up-to-date preview. (Issue #812: PR #755 was waiting on an out-of-date preview run.)

```diff
-concurrency: preview-${{ github.ref }}
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
```

## Why this wasn't done by @claude

The `@claude` run triggered on #812 (run 26417812630) failed and produced nothing — partly the jq-single-array crash in the prose-post step (fixed in unmerged #813), but fundamentally because this edits `.github/workflows/preview.yml` and `GITHUB_TOKEN` can't push workflow-file changes (the #800 limitation). So it's done here as a direct local PR.

## Test plan

- [ ] Verify YAML parses (done locally)
- [ ] After merge, push two commits in quick succession to a PR branch and confirm the first preview run is cancelled rather than both running to completion in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)