### PR TITLE
claude-code-review: stop self-cancelling when the review pushes a fix

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,9 +25,23 @@ on:
 # this, an overlapping second run reads an already-cleared list, stashes
 # [], and on restore wipes the original reviewers permanently. Cancel
 # the in-flight run on a new push so the freshest diff wins.
+#
+# BUT: `cancel-in-progress` must NOT fire for runs that the job-level
+# `if:` below will skip. This workflow can push fix commits in tag
+# mode (track_progress), and that push fires a `pull_request:
+# synchronize` event whose new run lands in this same group. GitHub
+# evaluates concurrency cancellation BEFORE the job `if:`, so without
+# the guard below that doomed-to-skip run would cancel the very run
+# that pushed the fix — mid-finalization, leaving a frozen tracking
+# comment (observed on PR #809 run 26423194992: it pushed 545a9c032,
+# then the resulting synchronize event cancelled it and then skipped
+# itself via the bot-actor `if:`). So gate cancel-in-progress on the
+# SAME expression as the job `if:`: a run only cancels in-progress
+# peers when it would itself actually run. (Keep this expression in
+# sync with the job `if:` below.)
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]')) }}
 
 jobs:
   claude-review:
@@ -38,6 +52,10 @@ jobs:
     # etc.) should still get a review fired; without this, those PRs are
     # stuck on whatever verdict was generated when they were first opened.
     # See d-morrison/rme#801 for the original symptom report.
+    #
+    # The `concurrency.cancel-in-progress` expression above mirrors this
+    # condition — keep the two in sync so a run that skips here never
+    # cancels an in-progress peer on its way out.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))


### PR DESCRIPTION
## Problem

The `claude-code-review.yml` workflow self-cancels when it pushes a fix commit.

In tag mode (`track_progress: true`) the code-review plugin can apply fixes and push commits. That push fires a `pull_request: synchronize` event, whose new run lands in the same `claude-review-<PR>` concurrency group. Since GitHub evaluates **concurrency cancellation before the job-level `if:`**, the new run — which is destined to *skip* via the bot-actor filter — still cancels the in-flight run that pushed the fix, on its way out.

### Observed on PR #809 (run 26423194992)

1. Review run starts on `44e6ffdf8`, posts a `track_progress` checklist.
2. Investigates (items 1–3), then pushes fix commit `545a9c032`.
3. That push's `synchronize` event queues run `26423497531` in `claude-review-809`.
4. `cancel-in-progress: true` cancels `26423194992` — the run that just pushed — mid-finalization. Checklist frozen at 3/9, no summary.
5. Run `26423497531` then skips (bot actor).

The fix commit landed (pushed before the cancel), but the session died incomplete and wasted compute.

## Fix

Gate `cancel-in-progress` on the **same expression as the job `if:`**:

```yaml
cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]')) }}
```

A run now only cancels in-progress peers when it would itself actually run. Effect:
- **Bot-triggered `pull_request`** (the workflow's own fix-push synchronize, Dependabot, etc.) → `cancel-in-progress: false` → no longer cancels the run that triggered it (and still skips via `if:`).
- **Human pushes** + **`workflow_dispatch`** → `cancel-in-progress: true` → still cancel stale reviews, as before.

Added cross-reference comments so the `concurrency` expression and the job `if:` stay in sync.

## Test plan

- [ ] Verify YAML parses (done locally)
- [ ] Trigger a review that pushes a fix on a test PR; confirm the run completes (posts its summary / finishes its checklist) instead of being cancelled by its own push
- [ ] Push two human commits in quick succession to a PR; confirm the older review is still cancelled (cancel-in-progress preserved for human pushes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)