### PR TITLE
claude-code-review: gate track_progress on event_name (#801 option 2)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -147,7 +147,22 @@ jobs:
           # PRs. track_progress forces tag mode, which creates a tracking
           # comment up front via createInitialComment() and updates it at the
           # end — guaranteeing a PR comment regardless of plugin output.
-          track_progress: 'true'
+          #
+          # BUT the action rejects track_progress for workflow_dispatch
+          # ("track_progress is only supported for events: pull_request,
+          # issues, issue_comment, pull_request_review_comment,
+          # pull_request_review"), failing the whole step. Every
+          # workflow_dispatch of this workflow hit that — including the
+          # dispatch paths in claude.yml (the post-commit dispatch and
+          # the @claude-review dispatch), which were silently 100%
+          # failing (see issue #801 option 2; confirmed on run
+          # 26425354090). So gate it on event_name: keep tag mode for
+          # the pull_request path (where the guaranteed tracking comment
+          # matters), fall back to agent mode for dispatched runs.
+          # Caveat: dispatched runs may now be silent on small/mechanical
+          # PRs where the plugin scores <80 — acceptable vs. the
+          # dispatch path failing outright.
+          track_progress: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           # Bundle the tracking comment into a single sticky per PR rather than
           # a new comment each run. (Only consulted in tag mode.) The previous
           # sticky is deleted in the step above so the new one always lands at


### PR DESCRIPTION
Implements **option 2 of #801**, deferred earlier and now justified by concrete breakage found while testing #817.

## Problem

`track_progress: 'true'` was unconditional. The action rejects `track_progress` for `workflow_dispatch`:

```
Action failed with error: track_progress is only supported for events:
pull_request, issues, issue_comment, pull_request_review_comment,
pull_request_review. Current event: workflow_dispatch
```

So **every `workflow_dispatch` invocation of `claude-code-review.yml` fails at the action step** — including the two dispatch paths I added earlier:
- `claude.yml`'s "Re-request review and dispatch code review" post-step
- the "@claude review → dispatch" step from #805

Both have been silently producing failed review runs. Confirmed on run `26425354090` (a dispatch I fired while testing #817).

## Fix

```yaml
track_progress: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
```

- `pull_request` events → `track_progress: 'true'` (keeps the guaranteed tracking comment where it matters)
- `workflow_dispatch` → `'false'` (agent mode)

Documented tradeoff: dispatched runs may be silent on small/mechanical PRs where the plugin scores <80 — strictly better than the dispatch failing outright.

## Test plan

- [ ] Verify YAML parses (done locally)
- [ ] After merge, `gh workflow run claude-code-review.yml -f pr_number=<N>` and confirm it runs to completion instead of failing on track_progress
- [ ] Confirm a normal `pull_request` review still posts its tracking comment (tag mode preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)