### PR TITLE
[TEST - do not merge] verify #817 self-cancel fix

### DIFF
--- a/_test-verify-817.qmd
+++ b/_test-verify-817.qmd
@@ -5,7 +5,7 @@ self-cancellation fix (#817). It is not referenced in `_quarto.yml`
 and should be deleted with its PR.
 
 For background on the chain rule, see the
-[chain rule](math-prereqs.html#thm-chain-rule).
+[chain rule](chapters/math-prereqs.qmd#thm-chain-rule).
 
-The derivative of \(f(x) = x^2\) is computed using raw LaTeX here:
-$\frac{d}{dx} x^2 = 2x$.
+The derivative of $f(x) = x^2$ is computed using the `\deriv{}` macro here:
+$\deriv{x} x^2 = 2x$.

--- a/_test-verify-817.qmd
+++ b/_test-verify-817.qmd
@@ -1,0 +1,11 @@
+# Test page (verifying PR #817)
+
+This file is a throwaway used to verify the `claude-code-review.yml`
+self-cancellation fix (#817). It is not referenced in `_quarto.yml`
+and should be deleted with its PR.
+
+For background on the chain rule, see the
+[chain rule](math-prereqs.html#thm-chain-rule).
+
+The derivative of \(f(x) = x^2\) is computed using raw LaTeX here:
+$\frac{d}{dx} x^2 = 2x$.


### PR DESCRIPTION
Throwaway PR to verify the #817 self-cancellation fix. Contains deliberate, plugin-fixable convention violations (.html link that should be .qmd; raw LaTeX instead of custom macros). Watching whether the auto-triggered code review pushes a fix and **completes** instead of being cancelled by its own push. Will be closed without merging.