### PR TITLE
fix invalid spell-check permission rule in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
       "Bash(gh run list *)",
       "Bash(quarto render *)",
       "Bash(Rscript -e 'lintr::lint*)",
-      "Bash(Rscript -e 'spelling::spell_check_package()')"
+      "Bash(Rscript -e 'spelling::spell_check_package*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

`/doctor` flagged the spell-check allow rule as invalid:

```
Invalid permission rule "Bash(Rscript -e 'spelling::spell_check_package()')" was skipped: Empty parentheses.
```

The literal `()` in `spell_check_package()` tripped the permission parser's empty-parentheses check, so the rule was dropped entirely.

## Change

Replace the trailing `()` with a `*` wildcard, matching the adjacent `lintr::lint*` rule:

```
"Bash(Rscript -e 'spelling::spell_check_package*)"
```

Still matches the pre-commit `Rscript -e 'spelling::spell_check_package()'` command, and the parser no longer rejects it.

## Test plan

- [ ] `/doctor` no longer reports the empty-parentheses error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)