### PR TITLE
claude-code-review: init latex-macros submodule for the reviewer

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,6 +83,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Initialize the latex-macros submodule so the reviewer can read its
+      # contents — without this, reviews of files that `{{< include >}}` or
+      # reference latex-macros report "the latex-macros submodule is not
+      # initialized in this environment" (see PR #806). Mirrors claude.yml's
+      # submodule step: the `insteadOf` rule authenticates the clone with
+      # SUBMODULES_TOKEN (a fine-grained PAT scoped to the submodule repos),
+      # since the default GITHUB_TOKEN can't read them.
+      - name: Checkout submodules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.SUBMODULES_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git submodule update --init --recursive --depth 1
+
       # The reviewer stash/restore is a serialization signal: we clear the
       # human reviewers before Claude runs so they aren't notified mid-run,
       # then re-add them when Claude finishes so the re-add fires a fresh


### PR DESCRIPTION
## Problem

On [PR #806](https://github.com/d-morrison/rme/pull/806) the Claude reviewer reported **"the latex-macros submodule is not initialized in this environment"** — so it can't read files that `{{< include >}}` or reference `latex-macros/`, and reviews of macro-related changes are blind to the submodule content.

Cause: `claude-code-review.yml`'s checkout uses only `fetch-depth: 1` with no submodule init, unlike `claude.yml` (the agent), which initializes submodules.

## Fix

Add the same `Checkout submodules` step `claude.yml` already uses, right after the checkout:

```yaml
- name: Checkout submodules
  run: |
    git config --global url."https://x-access-token:${{ secrets.SUBMODULES_TOKEN }}@github.com/".insteadOf "https://github.com/"
    git submodule update --init --recursive --depth 1
```

The `insteadOf` rule authenticates the submodule clone with `SUBMODULES_TOKEN` (a fine-grained PAT scoped to the submodule repos) — the default `GITHUB_TOKEN` can't read them.

## Test plan

- [ ] Trigger a review on a PR that touches or includes `latex-macros` content; confirm the reviewer can read the submodule files instead of reporting it uninitialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)