### PR TITLE
Stop @claude polling gh-api calls being denied over quoting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,12 +2,18 @@
   "permissions": {
     "allow": [
       "Bash(gh api repos/d-morrison/rme/*)",
+      "Bash(gh api 'repos/d-morrison/rme/*)",
       "Bash(gh pr view *)",
       "Bash(gh pr list *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh pr status *)",
       "Bash(gh issue view *)",
       "Bash(gh issue list *)",
       "Bash(gh run view *)",
       "Bash(gh run list *)",
+      "Bash(gh workflow view *)",
+      "Bash(gh workflow list *)",
       "Bash(quarto render *)",
       "Bash(Rscript -e 'lintr::lint*)",
       "Bash(Rscript -e 'spelling::spell_check_package*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -385,10 +385,15 @@ jobs:
                `issues` triggers — the GitHub-Actions expression
                `${{ github.event.issue.number || github.event.pull_request.number }}`
                is already substituted in below):
+               (the URLs are NOT quoted — they contain no shell-special
+               characters after substitution, and the allowed-tools pattern
+               `Bash(gh api repos/<repo>/*)` only matches the unquoted form;
+               a leading quote like `gh api 'repos/...` fails the match and
+               the call is denied — see PR #806 comment 4539906359):
                ```
-               gh api 'repos/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}/comments' --paginate
-               gh api 'repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/comments' --paginate   # PRs only
-               gh api 'repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/reviews'  --paginate   # PRs only
+               gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}/comments --paginate
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/comments --paginate   # PRs only
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/reviews  --paginate   # PRs only
                ```
 
             2. From the combined response, identify entries where ALL of:


### PR DESCRIPTION
Fixes the root cause behind [PR #806 comment 4539906359](https://github.com/d-morrison/rme/pull/806#issuecomment-4539906359) — the `/fewer-permission-prompts` analysis found that the recurring `gh api` permission denials in `@claude` runs come from **quoting**, not a missing scope.

## Root cause

The late-comment polling prompt instructs Claude to run:

```
gh api 'repos/d-morrison/rme/issues/N/comments' --paginate
```

But the allowed-tools pattern is `Bash(gh api repos/d-morrison/rme/*)`. The leading single-quote (`gh api 'repos/...`) means the command text doesn't start with `gh api repos/...`, so the match **fails** and the call is denied. This is the source of the `permission_denials_count` we kept seeing on `@claude` runs.

## Fixes

- **`claude.yml`** — de-quote the three `gh api` examples in the polling prompt. The URLs contain no shell-special characters after `${{ }}` substitution, so quoting was unnecessary; unquoted, they match the existing pattern.
- **`.claude/settings.json`** — add `Bash(gh api 'repos/d-morrison/rme/*)` as defense for any quoted `gh api` Claude constructs on its own, plus the read-only helpers the analysis flagged (`gh pr diff`/`checks`/`status`, `gh workflow view`/`list`). These reach the CI agent via `settingSources: [project]` and also help local sessions.

## Test plan

- [x] Trigger `@claude` on a PR and confirm the polling `gh api` calls run without a permission denial (lower `permission_denials_count` in the run log). Same-PR before/after on #779: run [26431229814](https://github.com/d-morrison/rme/actions/runs/26431229814) (2026-05-26 03:52 UTC, pre-merge — polling prompt still quoted) ended at `permission_denials_count: 42`; run [26917221781](https://github.com/d-morrison/rme/actions/runs/26917221781) (2026-06-03 22:33 UTC, post-merge — prompt unquoted as fixed) ended at `permission_denials_count: 5`. Residual non-polling denials are unrelated (e.g. `git push`, which is intentionally disallowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
