### PR TITLE
Add Δx̃ form and a proof to thm-hazard-ratio-ph

### DIFF
--- a/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
@@ -73,10 +73,11 @@ $$
 \ea
 $$
 
-The second equality writes the ratio as the exponential of a difference of
-logarithms; the third is the definition of $\diffloghaz$ as that difference;
-the fourth is @lem-diffloghaz-ph; and the last uses
-$\diffvx \eqdef \vx - \vxs$.
+Expanding the definition of $\theta$, the first equality writes the ratio
+as the exponential of a difference of logarithms;
+the second applies the definition of $\diffloghaz$ as that difference;
+the third is @lem-diffloghaz-ph;
+and the last substitutes $\diffvx \eqdef \vx - \vxs$.
 
 :::
 

--- a/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
@@ -77,9 +77,11 @@ Expanding the definition of $\theta$, the first equality writes the ratio
 as the exponential of a difference of logarithms;
 the second applies the definition of $\diffloghaz$ as that difference;
 the third is @lem-diffloghaz-ph;
-and the last substitutes $\diffvx \eqdef \vx - \vxs$.
+and the last substitutes $\diffvx$ for $\vx - \vxs$.
 
 :::
+
+{{< slidebreak >}}
 
 So for proportional hazards models, we can write the hazard ratio using a shorthand notation:
 

--- a/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
@@ -37,7 +37,7 @@ $$
 
 :::{#thm-hazard-ratio-ph}
 
-If $\loghaz(t|\vx) = \loghaz_0(t) + \reglincomb$, then: 
+If $\loghaz(t|\vx) = \loghaz_0(t) + \reglincomb$, then:
 
 $$
 \ba
@@ -45,8 +45,38 @@ $$
 &= \expf{\diffloghaz(t|\vx: \vxs)}
 \\
 &= \expf{(\vx - \vxs) \cdot \beta}
+\\
+&= \expf{\diffvx \cdot \beta}
 \ea
 $$
+
+where $\diffvx \eqdef \vx - \vxs$ is the difference in covariate vectors.
+
+:::
+
+{{< slidebreak >}}
+
+::: proof
+
+$$
+\ba
+\theta(t|\vx: \vxs)
+&\eqdef \frac{\haz(t|\vx)}{\haz(t|\vxs)}
+\\
+&= \expf{\loghaz(t|\vx) - \loghaz(t|\vxs)}
+\\
+&= \expf{\diffloghaz(t|\vx: \vxs)}
+\\
+&= \expf{(\vx - \vxs) \cdot \beta}
+\\
+&= \expf{\diffvx \cdot \beta}
+\ea
+$$
+
+The second equality writes the ratio as the exponential of a difference of
+logarithms; the third is the definition of $\diffloghaz$ as that difference;
+the fourth is @lem-diffloghaz-ph; and the last uses
+$\diffvx \eqdef \vx - \vxs$.
 
 :::
 


### PR DESCRIPTION
## Summary

Extends `{#thm-hazard-ratio-ph}` in `_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd`:

- Adds a line to the equation chain reducing $(\vx - \vxs)\cdot\beta$ to $\diffvx \cdot \beta$, with a note that $\diffvx \eqdef \vx - \vxs$.
- Adds a short proof chaining from the hazard-ratio definition $\theta(t\mid\vx:\vxs) \eqdef \haz(t\mid\vx)/\haz(t\mid\vxs)$ through `@lem-diffloghaz-ph`, mirroring the proof treatment of the neighbouring `{#thm-hazard-ratio-vs-baseline-ph}`.

Closes #829.

## Test plan

- [x] `quarto render chapters/proportional-hazards-models.qmd --to html` — renders; `@lem-diffloghaz-ph` resolves (no `?@`)
- [x] `spelling::spell_check_package()` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)