### PR TITLE
claude.yml: commit residual staged/untracked edits before the HEAD-unchanged check

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -797,6 +797,17 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Sweep any staged-but-uncommitted edits into a commit FIRST.
+          # Claude sometimes runs `git add` without `git commit`; without this,
+          # those edits are silently dropped by the HEAD-unchanged check below
+          # (it compares HEAD to the recorded starting SHA, which a bare
+          # `git add` doesn't move). Back-ported from UCD-SERG/shigella#24.
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "claude[bot]"
+            git config user.email "claude[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "@claude: auto-commit residual uncommitted changes"
+          fi
           CURRENT_SHA=$(git rev-parse HEAD)
           if [ "$CURRENT_SHA" = "$STARTING_SHA" ]; then
             echo "No new commits on $BRANCH — Claude produced no changes; skipping push/PR."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -797,16 +797,12 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # Sweep any staged-but-uncommitted edits into a commit FIRST.
-          # Claude sometimes runs `git add` without `git commit`; without this,
-          # those edits are silently dropped by the HEAD-unchanged check below
-          # (it compares HEAD to the recorded starting SHA, which a bare
-          # `git add` doesn't move). Back-ported from UCD-SERG/shigella#24.
+          # Sweep changes Claude staged or left untracked but didn't commit, so the HEAD-unchanged check below doesn't drop them.
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "claude[bot]"
             git config user.email "claude[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "@claude: auto-commit residual uncommitted changes"
+            git commit -m "chore: auto-commit residual staged/untracked changes from @claude session"
           fi
           CURRENT_SHA=$(git rev-parse HEAD)
           if [ "$CURRENT_SHA" = "$STARTING_SHA" ]; then

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -802,7 +802,8 @@ jobs:
             git config user.name "claude[bot]"
             git config user.email "claude[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "chore: auto-commit residual staged/untracked changes from @claude session"
+            git commit -m "chore: auto-commit residual staged/untracked changes from @claude session" \
+              || { echo "::error::auto-commit of residual @claude changes failed"; exit 1; }
           fi
           CURRENT_SHA=$(git rev-parse HEAD)
           if [ "$CURRENT_SHA" = "$STARTING_SHA" ]; then


### PR DESCRIPTION
## Summary

Back-ports one hardening fix from `UCD-SERG/shigella` (PR #24) to the **"Push branch and open draft PR for issue trigger"** step.

**Problem:** that step decides "Claude made no changes" by comparing `git rev-parse HEAD` to the branch's recorded starting SHA. If Claude ran `git add` but never `git commit` (an observed behavior), HEAD hasn't moved — so the step exits early and the staged edits are silently discarded at runner cleanup.

**Fix:** before the HEAD-unchanged check, sweep any uncommitted/staged changes into a commit. No-op when the tree is clean or Claude already committed.

### Why only this one nugget

shigella's recent work is mostly a *direct-CLI bypass* of `anthropics/claude-code-action` (workaround for action#1281). The other improvements there — prompt-injection fencing, stderr-tail failure diagnostics, the sticky self-trigger marker — are specific to running `claude` headless ourselves. This repo uses the official action, which already fences prompt content and surfaces its own logs, so those don't apply. The staged-edits sweep is the one fix that also applies to the official-action push step here.

## Test plan

- [ ] YAML parses (verified locally).
- [ ] On an issue trigger where `@claude` stages but doesn't commit, confirm the residual changes are committed and pushed rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
