### PR TITLE
Post inline review comments; reply to inline comments in-thread

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -130,7 +130,11 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }}
+            /code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }} --comment
+
+            The `--comment` flag above is the plugin's documented switch for
+            inline posting; the prose below is belt-and-suspenders in case the
+            plugin drives inline mode off the tool calls rather than the flag.
 
             **Post line-specific findings as inline review comments** anchored
             to the relevant line(s) — use the inline-comment tool, not a prose

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -129,7 +129,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }}'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }}
+
+            **Post line-specific findings as inline review comments** anchored
+            to the relevant line(s) — use the inline-comment tool, not a prose
+            list in the summary. Reserve the top-level summary comment for a
+            brief overall verdict plus any finding not tied to a specific line;
+            don't restate each inline comment there.
           # Force tag mode (anthropics/claude-code-action src/modes/detector.ts).
           # In the default agent mode for pull_request events, the action never
           # posts any non-inline PR comment by itself (src/modes/agent/index.ts:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -342,7 +342,11 @@ jobs:
             deliverable and the post-step skips posting your text to
             avoid noise.) Don't write it as an internal log
             ("Investigated foo, found bar, will do baz") — write it
-            as the actual reply you want the requester to read.
+            as the actual reply you want the requester to read. When the
+            trigger was an inline review comment on the diff (a
+            `pull_request_review_comment`), your reply is posted as a threaded
+            reply to that exact comment — keep it focused on the line(s) that
+            comment is about.
 
             **Before declaring the task complete, check for additional
             @claude requests that arrived after the triggering event.**
@@ -679,11 +683,21 @@ jobs:
           … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"
           fi
 
-          # `gh issue comment` works for both issues and PRs (both
-          # post to the same `/repos/{owner}/{repo}/issues/{N}/comments`
-          # endpoint internally), so we don't need to branch on
-          # PR-vs-issue here.
-          gh issue comment "$ENTITY_NUMBER" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
+          BODY="$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")"
+          # When the trigger was an inline review comment, reply IN-THREAD to
+          # it (pulls/.../comments/<id>/replies) so the conversation stays
+          # anchored to the diff line. Every other trigger gets a top-level
+          # `gh issue comment` (issue and PR-conversation comments share the
+          # same endpoint). Fall back to top-level if the reply API fails
+          # (e.g. the parent review comment was deleted).
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            if jq -n --arg b "$BODY" '{body: $b}' \
+                 | gh api --method POST "repos/${{ github.repository }}/pulls/$ENTITY_NUMBER/comments/${{ github.event.comment.id }}/replies" --input - >/dev/null; then
+              exit 0
+            fi
+            echo "::warning::In-thread reply failed; falling back to a top-level comment."
+          fi
+          gh issue comment "$ENTITY_NUMBER" --body "$BODY" \
             || echo "::warning::Could not post Claude's response back to the source thread."
 
       # Dispatch the dedicated reviewer workflow when the triggering

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -690,9 +690,15 @@ jobs:
           # `gh issue comment` (issue and PR-conversation comments share the
           # same endpoint). Fall back to top-level if the reply API fails
           # (e.g. the parent review comment was deleted).
+          #
+          # The /replies endpoint requires the THREAD-ROOT comment id; a
+          # reply id returns 422. When the trigger is itself a reply,
+          # `in_reply_to_id` holds the root id (it is null at the thread
+          # root), so prefer it and fall back to `comment.id`.
+          REPLY_TARGET_ID="${{ github.event.comment.in_reply_to_id || github.event.comment.id }}"
           if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             if jq -n --arg b "$BODY" '{body: $b}' \
-                 | gh api --method POST "repos/${{ github.repository }}/pulls/$ENTITY_NUMBER/comments/${{ github.event.comment.id }}/replies" --input - >/dev/null; then
+                 | gh api --method POST "repos/${{ github.repository }}/pulls/$ENTITY_NUMBER/comments/$REPLY_TARGET_ID/replies" --input - >/dev/null; then
               exit 0
             fi
             echo "::warning::In-thread reply failed; falling back to a top-level comment."


### PR DESCRIPTION
## Summary

Two related review-interaction improvements (enable + encourage):

**1. Code-review workflow → post inline comments.** The inline-comment tool + `pull-requests: write` were already available, but the upstream `/code-review:code-review` plugin defaulted to a top-level summary with *prose* line-references. Strengthened the review prompt to require line-specific findings be posted as **inline review comments** anchored to the line(s), reserving the top-level comment for a brief verdict + non-line-anchorable notes.

**2. Agent workflow → reply to inline comments in-thread.** When the agent is triggered by a `pull_request_review_comment` (an inline comment on the diff), the prose-reply post-step now replies **in-thread** via `POST /repos/{owner}/{repo}/pulls/{N}/comments/{comment_id}/replies` instead of a detached top-level `gh issue comment`. Top-level is kept for issue / review-summary / issue-comment triggers. Falls back to a top-level comment if the reply API fails (e.g. the parent comment was deleted). A prompt nudge tells Claude its reply lands in-thread so it stays focused on that line.

## Caveat

The review behavior is partly driven by the upstream plugin, so the inline-comment encouragement may only partly move it — worth confirming on a live PR; the wording can be iterated.

## Test plan

- [ ] YAML parses (verified locally).
- [ ] Open a PR and confirm the review posts real inline comments (not a prose list).
- [ ] Post an inline `@claude ...` review comment on a PR; confirm the reply lands as a threaded reply to that comment, not a top-level comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
