### PR TITLE
Fix broken ?@def-risk-set crossref on the website

### DIFF
--- a/chapters/coxph-model-building.qmd
+++ b/chapters/coxph-model-building.qmd
@@ -502,7 +502,7 @@ r^S_{ik} =
 x_{ik}-\frac{\sum_{j\in \risksetf{t_i}} x_{jk}\,\hth\paren{\vx_j}}{\sum_{j\in \risksetf{t_i}} \hth\paren{\vx_j}}
 $$
 
-where $\risksetf{t_i}$ is the risk set (@def-risk-set) at event time $t_i$ of subject $i$,
+where $\risksetf{t_i}$ is the [risk set](intro-to-survival-analysis.qmd#def-risk-set) at event time $t_i$ of subject $i$,
 $x_{jk}$ is the value of predictor $k$ for subject $j$,
 and $\hth\paren{\vx_j}$ is the estimated risk score (@def-estimated-risk-score) for subject $j$.
 


### PR DESCRIPTION
## Summary

- `def-risk-set` is defined in the **intro-to-survival-analysis** chapter, but the Schoenfeld-residual definition (in `coxph-model-building.qmd`, which is included into the proportional-hazards-models page) referenced it as a bare `@def-risk-set`. Because this project renders as a **website** (not a book), bare cross-page crossrefs don't resolve — so it rendered as `?@def-risk-set` on the published [proportional-hazards-models page](https://d-morrison.github.io/rme/chapters/proportional-hazards-models.html#schoenfeld-residuals).
- Replaced it with a file-qualified markdown link `[risk set](intro-to-survival-analysis.qmd#def-risk-set)`, matching the cross-page reference convention used elsewhere in the repo.

## Verification

- Rendered `chapters/proportional-hazards-models.qmd` → `?@def-risk-set` is gone and the link to `intro-to-survival-analysis.html#def-risk-set` is present.

## Not included (tracked separately)

A site-wide sweep found other broken crossrefs of a **different kind** — six `exm-*` example references (`exm-oc-mi`, `exm-odds`, `exm-OR` in logistic-regression; `exm-cont-not-diff`, `exm-int-not-cont` in math-prereqs; `exm-bootstrap-distribution-toy` in basic-statistical-methods) that render as `?@` for a subtler reason (not nesting, not duplicate labels, not cross-page). Filed as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)