### PR TITLE
Update latex-macros submodule + migrate ratio/factor notation

### DIFF
--- a/_subfiles/exam-formula-sheet/_sec_epi204_glms-and-survival.qmd
+++ b/_subfiles/exam-formula-sheet/_sec_epi204_glms-and-survival.qmd
@@ -51,11 +51,11 @@ $$
 
 | Formula | Description |
 |:--------|:------------|
-| $\haz(t\mid\vx) = \haz_0(t)\cdot\theta(\vx)$ | Proportional hazards assumption |
-| $\cuhaz(t\mid\vx) = \cuhaz_0(t)\cdot\theta(\vx)$ | Cumulative hazard factorization |
+| $\haz(t\mid\vx) = \haz_0(t)\cdot\hazfactor(\vx)$ | Proportional hazards assumption |
+| $\cuhaz(t\mid\vx) = \cuhaz_0(t)\cdot\hazfactor(\vx)$ | Cumulative hazard factorization |
 | $\loghaz(t\mid\vx) = \loghaz_0(t) + \Delta\eta(\vx)$ | Log-hazard decomposition |
 | $\Delta\eta(\vx) = \dprod{\vx}{\vb} = \beta_1 x_1 + \cdots + \beta_p x_p$ | Linear predictor |
-| $\theta(\vx) = \expf{\Delta\eta(\vx)}$ | Hazard multiplier |
+| $\hazfactor(\vx) = \expf{\Delta\eta(\vx)}$ | Hazard multiplier |
 | $\defHR$ | Hazard ratio definition |
 | $\hr(t\mid\vx:\vxs) = \expf{\Delta\eta(\vx) - \Delta\eta(\vxs)} = \expf{\dprod{(\vx-\vxs)}{\vb}}$ | Hazard ratio formula |
 

--- a/_subfiles/logistic-regression/_def_OR.qmd
+++ b/_subfiles/logistic-regression/_def_OR.qmd
@@ -3,6 +3,6 @@
 The **odds ratio** for two conditional odds, $\odds_1$ and $\odds_2$,
 is the ratio of those odds:
 
-$$\theta(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
+$$\ror(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
 
 :::

--- a/_subfiles/logistic-regression/_exm-OR.qmd
+++ b/_subfiles/logistic-regression/_exm-OR.qmd
@@ -6,7 +6,7 @@ In @exm-oc-mi, the odds ratio for OC users versus OC-non-users is:
 
 $$
 \begin{aligned}
-\theta(\odds(OC), \odds(\neg OC))
+\ror(\odds(OC), \odds(\neg OC))
 &= \frac{\odds(OC)}{\odds(\neg OC)}\\
 &= \frac{`r pi_OC`}{`r pi_nOC`}\\
 &= `r pi_OC / pi_nOC`\\

--- a/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
+++ b/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
@@ -101,7 +101,7 @@ $$
 {\oddst(Y= 1|P=0, A = a + 1)}
 {\oddst(Y= 1|P=0, A = a)}
 \\
-&= \theta(\Delta a = 1 | P = 0)
+&= \ror(\Delta a = 1 | P = 0)
 \ea
 $$
 
@@ -178,8 +178,8 @@ participants with type B personality; that is,
 
 $$
 \ba
-\theta(\Delta a = 1 | P = 1)
-= \expf{\beta_{PA}} \times \theta(\Delta a = 1 | P = 0)
+\ror(\Delta a = 1 | P = 1)
+= \expf{\beta_{PA}} \times \ror(\Delta a = 1 | P = 0)
 \ea
 $$
 
@@ -188,8 +188,8 @@ or equivalently:
 $$
 \expf{\beta_{PA}} = 
 \frac
-{\theta(\Delta a = 1 | P = 1)}
-{\theta(\Delta a = 1 | P = 0)}
+{\ror(\Delta a = 1 | P = 1)}
+{\ror(\Delta a = 1 | P = 0)}
 $$
 
 :::

--- a/_subfiles/logistic-regression/_sec-2x2-OR-shortcut.qmd
+++ b/_subfiles/logistic-regression/_sec-2x2-OR-shortcut.qmd
@@ -26,7 +26,7 @@ From this table, we have:
 * $\hat\odds(Event|\neg Exposed) = \frac{c}{d}$
 (see @exr-odds-generic)
 
-* $\theta(Exposed,\neg Exposed) = \frac{\frac{a}{b}}{\frac{c}{d}} = \frac{ad}{bc}$
+* $\ror(Exposed,\neg Exposed) = \frac{\frac{a}{b}}{\frac{c}{d}} = \frac{ad}{bc}$
 
 
 ---

--- a/_subfiles/logistic-regression/_sec_OR-ratio-ratio.qmd
+++ b/_subfiles/logistic-regression/_sec_OR-ratio-ratio.qmd
@@ -7,7 +7,7 @@ so odds ratios are ratios of ratios:
 :::{#thm-or-ratio-ratio}
 $$
 \ba
-\theta(\odds_1, \odds_2)
+\ror(\odds_1, \odds_2)
 &= \frac{\odds_1}{\odds_2}
 \\
 &= \frac{\paren{\frac{\pi_1}{1-\pi_1}}}{\paren{\frac{\pi_2}{1-\pi_2}}}

--- a/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
+++ b/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
@@ -55,7 +55,7 @@ Simulated data from study of oral contraceptive use and heart attack risk
 
 * $\odds(OC|\neg MI) = P(OC|\neg MI)/(1 – P(OC|\neg MI) = \frac{4987}{9993} = `r 4987/9993`$
 
-* $\theta(OC,MI) = \frac{\odds(OC|MI)}{\odds(OC|\neg MI)} = \frac{13/7}{4987/9993} = `r (13/7)/(4987/9993)`$
+* $\ror(OC,MI) = \frac{\odds(OC|MI)}{\odds(OC|\neg MI)} = \frac{13/7}{4987/9993} = `r (13/7)/(4987/9993)`$
 
 ::: notes
 This is the same estimate we calculated in @exm-OR.

--- a/_subfiles/logistic-regression/_sec_ORs_reversible.qmd
+++ b/_subfiles/logistic-regression/_sec_ORs_reversible.qmd
@@ -9,7 +9,7 @@ Odds ratios have a special property: we can swap a covariate with the outcome, a
 
 For any two events $A$, $B$:
 
-$$\theta(A|B) = \theta(B|A)$$
+$$\ror(A|B) = \ror(B|A)$$
 
 :::
 
@@ -29,7 +29,7 @@ In @exm-oc-mi, we have:
 
 $$
 \begin{aligned}
-\theta(MI; OC)
+\ror(MI; OC)
 &\eqdef
 \frac{\odds(MI|OC)}{\odds(MI|\neg OC)}\\
 &\eqdef \frac
@@ -50,7 +50,7 @@ $$
 {\left(\frac{\Pr(OC|\neg MI)}{\Pr(\neg OC|\neg MI)}\right)}\\
 &\eqdef \frac{\odds(OC|MI)}
 {\odds(OC|\neg MI)}\\
-&\eqdef \theta(OC; MI)
+&\eqdef \ror(OC; MI)
 \end{aligned}
 $$
 :::
@@ -58,7 +58,7 @@ $$
 ---
 
 :::{#exr-2x2-generic}
-For @tbl-2x2-generic, show that $\hat\theta(Exposed, Unexposed) = \hat\theta(Event, \neg Event)$.
+For @tbl-2x2-generic, show that $\hat\ror(Exposed, Unexposed) = \hat\ror(Event, \neg Event)$.
 :::
 
 ---
@@ -73,7 +73,7 @@ Conditional odds ratios have the same reversibility property:
 
 For any three events $A$, $B$, $C$:
 
-$$\theta(A|B,C) = \theta(B|A,C)$$
+$$\ror(A|B,C) = \ror(B|A,C)$$
 :::
 
 ---

--- a/_subfiles/logistic-regression/_sec_logistic_summary.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_summary.qmd
@@ -26,20 +26,20 @@ $$\oddsf{\pi} = \frac{1}{\pi^{-1}-1} = \invf{\pi^{-1}-1}$$
 $$\odds(\neg A) = \frac{1-\pi}{\pi} = \pi^{-1}-1$$
 
 **Odds ratio**
-$$\theta(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
+$$\ror(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
 
 **OR as ratio of probability ratios**
 $$\ba
-\theta(\odds_1, \odds_2)
+\ror(\odds_1, \odds_2)
   &= \frac{\odds_1}{\odds_2} \\
   &= \frac{\paren{\frac{\pi_1}{1-\pi_1}}}{\paren{\frac{\pi_2}{1-\pi_2}}}
 \ea$$
 
 **Odds ratios are reversible**
-$$\theta(A|B) = \theta(B|A)$$
+$$\ror(A|B) = \ror(B|A)$$
 
 **Conditional ORs are reversible**
-$$\theta(A|B,C) = \theta(B|A,C)$$
+$$\ror(A|B,C) = \ror(B|A,C)$$
 
 :::
 

--- a/_subfiles/proportional-hazards-models/_cor-hazard-ratio-diffloghaz.qmd
+++ b/_subfiles/proportional-hazards-models/_cor-hazard-ratio-diffloghaz.qmd
@@ -2,6 +2,6 @@
 
 #### Hazard ratio vs difference of log-hazards
 
-$$\theta(t| \vx : \vxs) = \expf{\diffloghaz(t|\vx: \vxs)}$$
+$$\hr(t| \vx : \vxs) = \expf{\diffloghaz(t|\vx: \vxs)}$$
 
 :::

--- a/_subfiles/proportional-hazards-models/_cor-hazard-ratio-vs-baseline.qmd
+++ b/_subfiles/proportional-hazards-models/_cor-hazard-ratio-vs-baseline.qmd
@@ -1,6 +1,6 @@
 :::{#cor-hazard-ratio-vs-baseline}
 
-$$\theta(t|\vx)= \expf{\diffloghaz(t|\vx)}$$
+$$\hazfactor(t|\vx)= \expf{\diffloghaz(t|\vx)}$$
 
 :::
 
@@ -10,8 +10,8 @@ $$\theta(t|\vx)= \expf{\diffloghaz(t|\vx)}$$
 
 $$
 \ba
-\theta(t|\vx)
-&\eqdef \theta(t| \vx : \vec{0})
+\hazfactor(t|\vx)
+&\eqdef \hr(t| \vx : \vec{0})
 \\
 &= \expf{\diffloghaz(t|\vx)}
 \ea

--- a/_subfiles/proportional-hazards-models/_coxph-model-structure.qmd
+++ b/_subfiles/proportional-hazards-models/_coxph-model-structure.qmd
@@ -39,9 +39,9 @@ $\loghaz(t|\vx) \eqdef \logf{\lambda(t|\vx)} = \loghaz_0(t) + \diffloghaz(t|\vx)
 
 $$
 \ba
-\haz(t |\vx) &= \haz_0(t) \cdot \theta(\vx)
+\haz(t |\vx) &= \haz_0(t) \cdot \hazfactor(\vx)
 \\
-\cuhaz(t |\vx) &= \cuhaz_0(t) \cdot \theta(\vx)
+\cuhaz(t |\vx) &= \cuhaz_0(t) \cdot \hazfactor(\vx)
 \\
 \loghaz(t|\vx) &= \loghaz_0(t) + \diffloghaz(\vx)
 \ea
@@ -52,11 +52,11 @@ $$
 
 - **Link function**: 
   $$\logf{\haz(t|\vx)} = \loghaz(t|\vx)$$
-  $$\logf{\theta(\vx)} = \diffloghaz(\vx)$$
+  $$\logf{\hazfactor(\vx)} = \diffloghaz(\vx)$$
   
 - **Inverse link function**: 
   $$\haz(t|\vx) = \expf{\loghaz(t|\vx)}$$
-  $$\theta(\vx) = \expf{\diffloghaz(\vx)}$$
+  $$\hazfactor(\vx) = \expf{\diffloghaz(\vx)}$$
   
 
 **Linear Predictor Component**: 

--- a/_subfiles/proportional-hazards-models/_def-breslow-baseline-cuhaz-est.qmd
+++ b/_subfiles/proportional-hazards-models/_def-breslow-baseline-cuhaz-est.qmd
@@ -1,2 +1,2 @@
 $$\hat \cuhaz_0(t) =
-\sum_{t_i < t} \frac{d_i}{\sum_{k\in R(t_i)} \theta(x_k)}$$
+\sum_{t_i < t} \frac{d_i}{\sum_{k\in R(t_i)} \hazfactor(x_k)}$$

--- a/_subfiles/proportional-hazards-models/_def-estimated-risk-score.qmd
+++ b/_subfiles/proportional-hazards-models/_def-estimated-risk-score.qmd
@@ -2,12 +2,12 @@
 
 #### Estimated Risk Score
 
-The risk score $\hrf{\vx}$ (@def-risk-score)
+The risk score $\hazfactorf{\vx}$ (@def-risk-score)
 depends on the true, unknown coefficient vector $\vb$.
 After fitting the model,
 we estimate it by the **estimated risk score**,
 which substitutes the fitted coefficients $\hvb$ for $\vb$:
 
-$$\hth\paren{\vx} = \expf{\dprod{\vx}{\hvb}}$$
+$$\hat\hazfactor\paren{\vx} = \expf{\dprod{\vx}{\hvb}}$$
 
 :::

--- a/_subfiles/proportional-hazards-models/_def-hr-vs-baseline.qmd
+++ b/_subfiles/proportional-hazards-models/_def-hr-vs-baseline.qmd
@@ -1,6 +1,6 @@
 :::{#def-hr-vs-baseline}
 #### Hazard ratio versus baseline
 
-$$\theta(t|\vx) \eqdef \theta(t| \vx : \vec{0})$${#eq-def-hr-vs-0}
+$$\hazfactor(t|\vx) \eqdef \hr(t| \vx : \vec{0})$${#eq-def-hr-vs-0}
 
 :::

--- a/_subfiles/proportional-hazards-models/_def-ph-partial-lik.qmd
+++ b/_subfiles/proportional-hazards-models/_def-ph-partial-lik.qmd
@@ -2,7 +2,7 @@
 
 $$
 \ba
-\Lik^*_i &= \frac{\theta(\vx_i)}{\sum_{k \in R(t_i)} \theta(\vx_k)}
+\Lik^*_i &= \frac{\hazfactor(\vx_i)}{\sum_{k \in R(t_i)} \hazfactor(\vx_k)}
 \\
 \Lik^* &=
 \prod_{\set{i:\ d_i = 1}} \Lik^*_i

--- a/_subfiles/proportional-hazards-models/_def-risk-score.qmd
+++ b/_subfiles/proportional-hazards-models/_def-risk-score.qmd
@@ -7,12 +7,12 @@ with coefficient vector $\vb$,
 the **risk score** (also called the **hazard multiplier** or **partial hazard**)
 for a subject with covariate vector $\vx$ is:
 
-$$\hrf{\vx} = \expf{\reglincomb}$$
+$$\hazfactorf{\vx} = \expf{\reglincomb}$$
 
 :::
 
 ::: notes
-The risk score $\hrf{\vx}$ is a theoretical quantity
+The risk score $\hazfactorf{\vx}$ is a theoretical quantity
 depending on the true (unknown) parameter $\vb$.
 :::
 

--- a/_subfiles/proportional-hazards-models/_sec-surv-conditional-hazards.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-surv-conditional-hazards.qmd
@@ -132,6 +132,6 @@ $$
 
 :::{#cor-diffloghaz-log-HR}
 
-$$\diffloghaz(t|\vx) = \logf{\theta(t| \vx)}$$
+$$\diffloghaz(t|\vx) = \logf{\hazfactor(t| \vx)}$$
 
 :::

--- a/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
@@ -41,7 +41,7 @@ If $\loghaz(t|\vx) = \loghaz_0(t) + \reglincomb$, then:
 
 $$
 \ba
-\theta(t|\vx: \vxs)
+\hr(t|\vx: \vxs)
 &= \expf{\diffloghaz(t|\vx: \vxs)}
 \\
 &= \expf{(\vx - \vxs) \cdot \beta}
@@ -60,7 +60,7 @@ where $\diffvx \eqdef \vx - \vxs$ is the difference in covariate vectors.
 
 $$
 \ba
-\theta(t|\vx: \vxs)
+\hr(t|\vx: \vxs)
 &\eqdef \frac{\haz(t|\vx)}{\haz(t|\vxs)}
 \\
 &= \expf{\loghaz(t|\vx) - \loghaz(t|\vxs)}
@@ -73,7 +73,7 @@ $$
 \ea
 $$
 
-Expanding the definition of $\theta$, the first equality writes the ratio
+Expanding the definition of $\hr$, the first equality writes the ratio
 as the exponential of a difference of logarithms;
 the second applies the definition of $\diffloghaz$ as that difference;
 the third is @lem-diffloghaz-ph;
@@ -85,7 +85,7 @@ and the last substitutes $\diffvx$ for $\vx - \vxs$.
 
 So for proportional hazards models, we can write the hazard ratio using a shorthand notation:
 
-$$\theta(t| \vx : \vxs)  = \theta(\vx : \vxs)$$
+$$\hr(t| \vx : \vxs)  = \hr(\vx : \vxs)$$
 
 {{< slidebreak >}}
 
@@ -99,7 +99,7 @@ $$\diffloghaz(t|\vx)= \reglincomb$${#eq-diffloghaz-0-ph}
 
 If $\loghaz(t|\vx) = \loghaz_0(t) + \reglincomb$, then: 
 
-$$\theta(t|\vx) = \expf{\reglincomb}$$
+$$\hazfactor(t|\vx) = \expf{\reglincomb}$$
 
 :::
 
@@ -109,8 +109,8 @@ $$\theta(t|\vx) = \expf{\reglincomb}$$
 
 $$
 \ba
-\theta(t|\vx)
-&\eqdef \theta(t| \vx : \vec{0})
+\hazfactor(t|\vx)
+&\eqdef \hr(t| \vx : \vec{0})
 \\
 &= \expf{\diffloghaz(t|\vx)}
 \\
@@ -123,7 +123,7 @@ $$
 {{< slidebreak >}}
 
 :::{#thm-ph-haz-decomp}
-$$\haz(t|\vx) = \haz_0(t)\theta(\vx)$$
+$$\haz(t|\vx) = \haz_0(t)\hazfactor(\vx)$$
 :::
 
 {{< slidebreak >}}
@@ -136,7 +136,7 @@ Also:
 
 $$
 \ba
-\theta(\vx) &= \expf{\diffloghaz(\vx)}
+\hazfactor(\vx) &= \expf{\diffloghaz(\vx)}
 \\
 \logf{\haz(t|\vx)}
 &= \logf{\haz_0(t)} + \diffloghaz(\vx)
@@ -177,8 +177,8 @@ the ratio of the hazard functions
 $$
 \ba
 \frac{\haz(t|\vx_1)}{\haz(t|\vx_2)}
-&=\frac{\haz_0(t)\theta(\vx_1)}{\haz_0(t)\theta(\vx_2)}\\
-&=\frac{\theta(\vx_1)}{\theta(\vx_2)}\\
+&=\frac{\haz_0(t)\hazfactor(\vx_1)}{\haz_0(t)\hazfactor(\vx_2)}\\
+&=\frac{\hazfactor(\vx_1)}{\hazfactor(\vx_2)}\\
 \ea
 $$
 
@@ -199,13 +199,13 @@ has **proportional hazards** if the hazard ratio $\haz(t|\vx_1)/\haz(t|\vx_2)$ d
 
 $$
 \frac{\haz(t|\vx_1)}{\haz(t|\vx_2)}
-= \theta(\vx_1,\vx_2)
+= \hr(\vx_1,\vx_2)
 $$
 
 :::
 
 ::: notes
-As we saw above, Cox's proportional hazards model has this property, with $\theta(\vx_1,\vx_2) = \frac{\theta(\vx_1)}{\theta(\vx_2)}$.
+As we saw above, Cox's proportional hazards model has this property, with $\hr(\vx_1,\vx_2) = \frac{\hazfactor(\vx_1)}{\hazfactor(\vx_2)}$.
 :::
 
 {{< slidebreak >}}
@@ -214,15 +214,15 @@ As we saw above, Cox's proportional hazards model has this property, with $\thet
 
 ::: notes
 We are using two similar notations,
-$\theta(\vx,\vxs)$ and $\theta(\vx)$.
+$\hr(\vx,\vxs)$ and $\hazfactor(\vx)$.
 We can link these notations:
-$$\theta(\vx) \eqdef \theta(\vx, \vzero)$$
+$$\hazfactor(\vx) \eqdef \hr(\vx, \vzero)$$
 
 Then:
 :::
 
-$$\theta(\vx, \vxs) = \frac{\theta(\vx)}{\theta(\vxs)}$$
-$$\theta(\vzero) = \theta(\vzero, \vzero) = 1$$
+$$\hr(\vx, \vxs) = \frac{\hazfactor(\vx)}{\hazfactor(\vxs)}$$
+$$\hazfactor(\vzero) = \hr(\vzero, \vzero) = 1$$
 
 :::
 
@@ -233,7 +233,7 @@ The proportional hazards model also has additional notable properties:
 $$
 \ba
 \frac{\haz(t|\vx_1)}{\haz(t|\vx_2)}
-&=\frac{\theta(\vx_1)}{\theta(\vx_2)}\\
+&=\frac{\hazfactor(\vx_1)}{\hazfactor(\vx_2)}\\
 &=\frac{\expf{\eta(\vx_1)}}{\expf{\eta(\vx_2)}}\\
 &=\expf{\eta(\vx_1)-\eta(\vx_2)}\\
 &=\expf{\vx_1'\vb-\vx_2'\vb}\\
@@ -298,7 +298,7 @@ See also:
 
 ### Additional properties of the proportional hazards model
 
-If $\haz(t|\vx)= \haz_0(t)\theta(\vx)$, then:
+If $\haz(t|\vx)= \haz_0(t)\hazfactor(\vx)$, then:
 
 :::{#thm-ph-cuhaz}
 
@@ -308,9 +308,9 @@ $$
 \ba
 \cuhaz(t|\vx)
 &\eqdef \int_{u=0}^t \haz(u)du\\
-&= \int_{u=0}^t \haz_0(u)\theta(\vx)du\\
-&= \theta(\vx)\int_{u=0}^t \haz_0(u)du\\
-&= \theta(\vx)\cuhaz_0(t)
+&= \int_{u=0}^t \haz_0(u)\hazfactor(\vx)du\\
+&= \hazfactor(\vx)\int_{u=0}^t \haz_0(u)du\\
+&= \hazfactor(\vx)\cuhaz_0(t)
 \ea
 $$
 
@@ -345,7 +345,7 @@ $$
 :::{#thm-ph-surv}
 #### Survival functions are exponential multiples of $\surv_0(t)$
 
-$$\surv(t|\vx) = \sb{\surv_0(t)}^{\theta(\vx)}$$
+$$\surv(t|\vx) = \sb{\surv_0(t)}^{\hazfactor(\vx)}$$
 
 :::
 
@@ -356,9 +356,9 @@ $$
 \ba
 \surv(t|\vx)
 &= \expf{-\cuhaz(t|\vx)}\\
-&= \expf{-\theta(\vx)\cdot \cuhaz_0(t)}\\
-&= \paren{\expf{- \cuhaz_0(t)}}^{\theta(\vx)}\\
-&= \sb{\surv_0(t)}^{\theta(\vx)}\\
+&= \expf{-\hazfactor(\vx)\cdot \cuhaz_0(t)}\\
+&= \paren{\expf{- \cuhaz_0(t)}}^{\hazfactor(\vx)}\\
+&= \sb{\surv_0(t)}^{\hazfactor(\vx)}\\
 \ea
 $$
 

--- a/_subfiles/proportional-hazards-models/_sec_fit-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec_fit-coxph.qmd
@@ -14,8 +14,8 @@ and
 $$
 \ba
 \eta(\vx) &= \beta_1x_{1}+\cdots+\beta_p x_{p}\\
-\theta(\vx) &= \expf{\eta(\vx)}\\
-\haz(t|\vx)&= \haz_0(t)\expf{\eta(\vx)}=\theta(\vx) \haz_0(t)
+\hazfactor(\vx) &= \expf{\eta(\vx)}\\
+\haz(t|\vx)&= \haz_0(t)\expf{\eta(\vx)}=\hazfactor(\vx) \haz_0(t)
 \ea
 $$
 
@@ -30,7 +30,7 @@ $$
 \ba
 \Pr(f \text{ fails}|\text{1 failure at } t)
 &= \frac{\haz_0(t)\expf{\eta(\vx_f)}}{\sum_{k \in R(t)}\haz_0(t)\expf{\eta(\vx_k)}}\\
-&=\frac{\theta(\vx_f)}{\sum_{k \in R(t)} \theta(\vx_k)}
+&=\frac{\hazfactor(\vx_f)}{\sum_{k \in R(t)} \hazfactor(\vx_k)}
 \ea
 $$
 
@@ -72,7 +72,7 @@ for the coefficients.
 
 Once we have coefficient estimates
 $\hat{\vec{\beta}} =(\hat \beta_1,\ldots,\hat\beta_p)$,
-this also defines $\hat\eta(x)$ and $\hat\theta(x)$,
+this also defines $\hat\eta(x)$ and $\hat\hazfactor(x)$,
 and then the estimated base cumulative hazard function is 
 
 {{< include _subfiles/proportional-hazards-models/_def-breslow-baseline-cuhaz-est.qmd >}}

--- a/_subfiles/proportional-hazards-models/_thm-diff-loghaz.qmd
+++ b/_subfiles/proportional-hazards-models/_thm-diff-loghaz.qmd
@@ -3,10 +3,10 @@
 
 If $\diffloghaz(t|\vx : \vxs)$ is the difference in log-hazard
 between covariate patterns $\vx$ and $\vxs$ at time $t$,
-and $\theta(t| \vx : \vxs)$ is corresponding hazard ratio,
+and $\hr(t| \vx : \vxs)$ is corresponding hazard ratio,
 then:
 
-$$\diffloghaz(t|\vx : \vxs)= \logf{\theta(t| \vx : \vxs)}$$
+$$\diffloghaz(t|\vx : \vxs)= \logf{\hr(t| \vx : \vxs)}$$
 :::
 
 {{< slidebreak >}}
@@ -24,7 +24,7 @@ $$
 \\
 &= \logf{\frac{\haz(t|\vx)}{\haz(t|\vxs)}}
 \\
-&= \logf{\theta(t| \vx : \vxs)}
+&= \logf{\hr(t| \vx : \vxs)}
 \ea
 $$
 

--- a/chapters/parametric-survival-models.qmd
+++ b/chapters/parametric-survival-models.qmd
@@ -273,8 +273,8 @@ $$
 h(T=t|X=x) 
 &\stackrel{\text{def}}{=} p(T=t|X=x,T \ge t)\\
 &= \haz(t|X=0)\cdot \exp{\eta(x)}\\
-&= \haz(t|X=0)\cdot \theta(x)\\
-&= \haz_0(t)\cdot \theta(x)
+&= \haz(t|X=0)\cdot \hazfactor(x)\\
+&= \haz_0(t)\cdot \hazfactor(x)
 \end{aligned}
 $$
 
@@ -283,17 +283,17 @@ and correspondingly,
 $$
 \begin{aligned}
 \cuhaz(t|x)
-&= \theta(x)\cuhaz_0(t)\\
+&= \hazfactor(x)\cuhaz_0(t)\\
 \surv(t|x)
 &= \expf{-\cuhaz(t|x)}\\
-&= \expf{-\theta(x)\cdot \cuhaz_0(t)}\\
-&= \paren{\expf{- \cuhaz_0(t)}}^{\theta(x)}\\
-&= \paren{\surv_0(t)}^{\theta(x)}\\
+&= \expf{-\hazfactor(x)\cdot \cuhaz_0(t)}\\
+&= \paren{\expf{- \cuhaz_0(t)}}^{\hazfactor(x)}\\
+&= \paren{\surv_0(t)}^{\hazfactor(x)}\\
 \end{aligned}
 $$
 
 An alternative modeling assumption would be
-$$\surv(t|X=x)=\surv_0(t\cdot \theta(x))$$ where $\theta(x)=\expf{\eta(x)}$,
+$$\surv(t|X=x)=\surv_0(t\cdot \hazfactor(x))$$ where $\hazfactor(x)=\expf{\eta(x)}$,
 $\eta(x) =\beta_1x_1+\cdots+\beta_px_p$, and $\surv_0(t)=\P(T\ge t|X=0)$ is
 the base survival function.
 
@@ -303,13 +303,13 @@ $$
 \begin{aligned}
 \Expp[T|X=x]
 &= \int_{t=0}^{\infty} \surv(t|x)dt\\
-&= \int_{t=0}^{\infty} \surv_0(t\cdot \theta(x))dt\\
-&= \int_{u=0}^{\infty} \surv_0(u)du \cdot \theta(x)^{-1}\\
-&= \theta(x)^{-1} \cdot \int_{u=0}^{\infty} \surv_0(u)du\\
-&= \theta(x)^{-1} \cdot \Expp[T|X=0]\\
+&= \int_{t=0}^{\infty} \surv_0(t\cdot \hazfactor(x))dt\\
+&= \int_{u=0}^{\infty} \surv_0(u)du \cdot \hazfactor(x)^{-1}\\
+&= \hazfactor(x)^{-1} \cdot \int_{u=0}^{\infty} \surv_0(u)du\\
+&= \hazfactor(x)^{-1} \cdot \Expp[T|X=0]\\
 \end{aligned}
 $$ So the mean of $T$ given $X=x$ is the baseline mean divided by
-$\theta(x) = \exp{\eta(x)}$.
+$\hazfactor(x) = \exp{\eta(x)}$.
 
 This modeling strategy is called an accelerated failure time model,
 because covariates cause uniform acceleration (or slowing) of failure
@@ -319,8 +319,8 @@ Additionally:
 
 $$
 \begin{aligned}
-\cuhaz(t|x) &= \cuhaz_0(\theta(x)\cdot t)\\
-\haz(t|x) &= \theta(x) \cdot \haz_0(\theta(x)\cdot t)
+\cuhaz(t|x) &= \cuhaz_0(\hazfactor(x)\cdot t)\\
+\haz(t|x) &= \hazfactor(x) \cdot \haz_0(\hazfactor(x)\cdot t)
 \end{aligned}
 $$
 
@@ -329,13 +329,13 @@ If the base distribution is exponential with parameter $\lambda$ then
 $$
 \begin{aligned}
 \surv(t|x)
-&= \exp{-\lambda \cdot t \theta(x)}\\
-&= [\exp{-\lambda t}]^{\theta(x)}\\
+&= \exp{-\lambda \cdot t \hazfactor(x)}\\
+&= [\exp{-\lambda t}]^{\hazfactor(x)}\\
 \end{aligned}
 $$
 
 which is an exponential model with base hazard multiplied by
-$\theta(x)$, which is also the proportional hazards model.
+$\hazfactor(x)$, which is also the proportional hazards model.
 
 ::: hidden
 In terms of the log survival time $Y=\log{T}$ the model can be written

--- a/chapters/prf-OR-reversible.qmd
+++ b/chapters/prf-OR-reversible.qmd
@@ -1,6 +1,6 @@
 $$
 \ba
-\theta(A|B) &\eqdef\frac{\odds(A|B)}{\odds(A|\neg B)}
+\ror(A|B) &\eqdef\frac{\odds(A|B)}{\odds(A|\neg B)}
 \\ &= \frac
 {\paren{\frac{\p(A|B)}{\p(\neg A|B)}}}
 {\paren{\frac{\p(A|\neg B)}{\p(\neg A| \neg B)}}}
@@ -23,6 +23,6 @@ $$
 \paren{\frac{\p(B,A)}{\blue{\p(\neg B, A)}}}
 \paren{\frac{\p(\neg B, \neg A)}{\red{\p(B,\neg A)}}}
 \\ &= \text{[reverse the preceding steps]}
-\\ &= \theta(B|A)
+\\ &= \ror(B|A)
 \ea
 $$


### PR DESCRIPTION
## What

1. **Bumps the `latex-macros` submodule** to `af44e55`, which adds the typed-subscript ratio system (`\ror`=θ_ω, `\hazratio`/`\hr`=θ_λ, …) and the new **typed factor macros** (`\hazfactor`, `\oddsfactor`, `\ratefactor`, `\riskfactor`, `\prevfactor`, `\cuhazfactor`, `\survfactor`, function forms, and `\hazff`-style shorthands). See d-morrison/macros#57.

2. **Migrates the book's ratio/factor notation** to those typed macros, distinguishing:
   - **Ratios** — comparing **two explicit covariate patterns** → `\ror` (odds), `\hr`/`\hazratio` (hazard).
   - **Factors** — comparing **one pattern to the implicit baseline** → `\hazfactor` / `\hazfactorf` (e.g. the Cox risk score, the hazard multiplier).

### Mapping applied
- Odds ratios: bare `\theta(...)` → `\ror` (logistic-regression subfiles, `prf-OR-reversible`).
- Two-pattern hazard ratios `\theta(t|x:x*)`, `\theta(x_1,x_2)` → `\hr`.
- Hazard/risk-score factors `\theta(x)`, `\theta(t|x)`, and the risk score `\hrf{x}` → `\hazfactor` / `\hazfactorf` (proportional-hazards subfiles, `parametric-survival-models`, exam formula sheet).
- Estimated risk score `\hth(x)` → `\hat\hazfactor(x)`.

Factors render identically to ratios **today** (both θ_type); they're separate macros so that d-morrison/macros#56 (switch the *ratio* base symbol to koppa ϟ, factors keep θ) becomes a one-line change.

### Left unchanged (intentional)
- Per-subject **index-subscripted** factors `\theta_i` (Cox ties, Weibull derivation): stay plain `\theta` (they remain θ under #56 and can't take a type subscript without double-subscripting).
- Generic MLE/parameter `\theta` (estimation, MLEs, GLM natural parameter, polar coordinates, quasi-Poisson dispersion): unchanged — not ratios or factors.

## Validation
- Renders clean (HTML): `logistic-regression`, `proportional-hazards-models`, `parametric-survival-models`, `exam-formula-sheet`.
- `_def-estimated-risk-score` (only reached via `coxph-model-building`) validated by a standalone wrapper render.
- `lintr`: no new issues from these changes (one pre-existing `=`-assignment in an untouched chunk).
- `spelling::spell_check_package()`: no errors.

## Pre-existing, not caused by this PR
- `coxph-model-building.qmd` fails a **standalone** single-chapter render with `object 'legend_text_size' not found` — that variable is defined in `chapters/r-config.qmd` and is only in scope in the full-book build; it is unrelated to these math-notation edits (that file is not modified here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)