### PR TITLE
Use generic \ratio when a ratio's inputs are the quantities themselves

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -613,6 +613,21 @@ Residual and deviation helper macros include:
   use `\tp{(\vxs)}` not `\tp{\vxs}`.
   This avoids LaTeX "Double superscript" errors.
 
+**Ratio vs. factor macros**:
+
+- **Ratios** compare two quantities. Use the *generic* `\ratio` / `\ratiof` macro when the
+  inputs are the **quantities themselves** (the odds, hazards, rates, etc.) — the type of ratio
+  is clear from the inputs. For example, an odds ratio of two odds is `\ratio(\odds_1, \odds_2)`,
+  **not** `\ror(\odds_1, \odds_2)`.
+- Use the *type-subscripted* ratio macros (`\ror` for odds ratios, `\hazratio`/`\hr` for hazard
+  ratios, and `\rateratio`, `\riskratio`, `\prevratio`, `\cuhazratio`, …) only when the inputs are
+  **covariate patterns** (e.g. `\ror(\vx, \vxs)`, `\hr(t \mid \vx : \vxs)`), where the subscript
+  is needed to indicate which kind of ratio it is.
+- **Factors** compare **one** covariate pattern to the implicit baseline pattern. Use the
+  type-subscripted factor macros (`\hazfactor`, `\oddsfactor`, …; function forms `\hazfactorf` /
+  `\hazff`, …) — e.g. the Cox risk score `\hazfactor(\vx)`. Factors always take a covariate
+  pattern, so they keep their subscript.
+
 **Vector–scalar product ordering** (for dimensional clarity):
 
 - When multiplying a **column vector** `\vb` by a scalar `s`, write the **vector on the left**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ Before committing any `.qmd`, `.R`, or config file change:
 - Key macros: `\E{Y|X=x}`, `\ba`/`\ea`, `\tp{v}`, `\b`, `\g`, `\a`, `\devn(...)`, `\erf{...}`
 - Include every intermediate step in derivations — do not skip steps
 - Color coding: `\red{...}` for focal/extra terms, `\blue{...}` for shared terms
+- Ratios vs. factors:
+  - Use the generic `\ratio`/`\ratiof` macro when a ratio's inputs are the **quantities themselves** (the odds, hazards, rates, etc.) — e.g. `\ratio(\odds_1, \odds_2)`, **not** `\ror(\odds_1, \odds_2)` — because the type of ratio is clear from the inputs.
+  - Use the type-subscripted ratio macros (`\ror` for odds ratios, `\hazratio`/`\hr` for hazard ratios, `\rateratio`, `\riskratio`, `\prevratio`, `\cuhazratio`, …) only when the inputs are **covariate patterns** (e.g. `\ror(\vx,\vxs)`, `\hr(t\mid\vx:\vxs)`), where the subscript is needed to say which kind of ratio it is.
+  - Factors compare **one** covariate pattern to the implicit baseline pattern (e.g. the Cox risk score `\hazfactor(\vx)`); always use the subscripted factor macros (`\hazfactor`, `\oddsfactor`, …; function forms `\hazfactorf`/`\hazff`, …).
 
 ### Citations
 - Always use BibTeX keys with `@citekey` Pandoc syntax — never plaintext author-date

--- a/_subfiles/logistic-regression/_def_OR.qmd
+++ b/_subfiles/logistic-regression/_def_OR.qmd
@@ -3,6 +3,6 @@
 The **odds ratio** for two conditional odds, $\odds_1$ and $\odds_2$,
 is the ratio of those odds:
 
-$$\ror(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
+$$\ratio(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
 
 :::

--- a/_subfiles/logistic-regression/_exm-OR.qmd
+++ b/_subfiles/logistic-regression/_exm-OR.qmd
@@ -6,7 +6,7 @@ In @exm-oc-mi, the odds ratio for OC users versus OC-non-users is:
 
 $$
 \begin{aligned}
-\ror(\odds(OC), \odds(\neg OC))
+\ratio(\odds(OC), \odds(\neg OC))
 &= \frac{\odds(OC)}{\odds(\neg OC)}\\
 &= \frac{`r pi_OC`}{`r pi_nOC`}\\
 &= `r pi_OC / pi_nOC`\\

--- a/_subfiles/logistic-regression/_sec_OR-ratio-ratio.qmd
+++ b/_subfiles/logistic-regression/_sec_OR-ratio-ratio.qmd
@@ -7,7 +7,7 @@ so odds ratios are ratios of ratios:
 :::{#thm-or-ratio-ratio}
 $$
 \ba
-\ror(\odds_1, \odds_2)
+\ratio(\odds_1, \odds_2)
 &= \frac{\odds_1}{\odds_2}
 \\
 &= \frac{\paren{\frac{\pi_1}{1-\pi_1}}}{\paren{\frac{\pi_2}{1-\pi_2}}}

--- a/_subfiles/logistic-regression/_sec_logistic_summary.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_summary.qmd
@@ -26,11 +26,11 @@ $$\oddsf{\pi} = \frac{1}{\pi^{-1}-1} = \invf{\pi^{-1}-1}$$
 $$\odds(\neg A) = \frac{1-\pi}{\pi} = \pi^{-1}-1$$
 
 **Odds ratio**
-$$\ror(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
+$$\ratio(\odds_1, \odds_2) \eqdef \frac{\odds_1}{\odds_2}$$
 
 **OR as ratio of probability ratios**
 $$\ba
-\ror(\odds_1, \odds_2)
+\ratio(\odds_1, \odds_2)
   &= \frac{\odds_1}{\odds_2} \\
   &= \frac{\paren{\frac{\pi_1}{1-\pi_1}}}{\paren{\frac{\pi_2}{1-\pi_2}}}
 \ea$$


### PR DESCRIPTION
Follow-up to #850 (now merged): refines when to use the type-subscripted ratio macros vs. the generic one.

## Rule
- When a ratio's inputs are the **quantities themselves** (the odds, hazards, rates, …), use the **generic** `\ratio` / `\ratiof` — the ratio type is clear from the inputs, so the subscript is redundant.
- Use the **type-subscripted** ratio macros (`\ror`, `\hazratio`/`\hr`, `\rateratio`, `\riskratio`, `\prevratio`, `\cuhazratio`, …) only when the inputs are **covariate patterns** (e.g. `\ror(\vx,\vxs)`, `\hr(t\mid\vx:\vxs)`), where the subscript indicates which kind of ratio.
- **Factors** (one covariate pattern vs. the implicit baseline, e.g. the Cox risk score `\hazfactor(\vx)`) always take a covariate pattern, so they keep their subscript.

## Changes
- `\ror(\odds_1,\odds_2)` → `\ratio(\odds_1,\odds_2)` and `\ror(\odds(OC),\odds(\neg OC))` → `\ratio(...)` in `_def_OR`, `_sec_OR-ratio-ratio`, `_sec_logistic_summary`, `_exm-OR`.
- Covariate-pattern / event / exposure-group ratios are **unchanged** (`\ror(\vx,\vxs)`, `\ror(A|B)`, `\ror(Exposed,\neg Exposed)`, `\ror(\Delta a=1|P=0)`, `\hr(t|\vx:\vxs)`, …).
- Documents the rule in `CLAUDE.md` and `.github/copilot-instructions.md` (Math Notation sections).

The hazard-ratio definition (`\defHR` → `\hr(t|\vx:\vxs)`) already uses covariate-pattern inputs, so it correctly keeps its subscript.

## Validation
- `chapters/logistic-regression.qmd` renders clean; `spelling::spell_check_package()` clean; no R code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)