### PR TITLE
workflows/lint-changed-files: bypass gh PAT validation for ghs_ token format

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -36,13 +36,10 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
-          # `.token` is passed explicitly so gh skips its own PAT-format
-          # validation. The Actions runner now hands `secrets.GITHUB_TOKEN`
-          # as a `ghs_*` server-to-server token, which gh 1.5.0's
-          # `validate_gh_pat()` rejects outright (the fix for this lives
-          # in gh main / PR #233 but is not in any CRAN release yet, so
-          # bumping the pin is not an option). Bypassing validation works
-          # because Actions' token authenticates fine against the API.
+          # Explicit `.token` bypasses gh 1.5.0's validate_gh_pat(), which
+          # rejects the `ghs_*` server-to-server token Actions now issues.
+          # Remove once r-lib/gh#233 lands on CRAN (merged to gh main
+          # 2026-05-28, not yet released).
           files <- gh::gh(
             "GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files",
             .token = Sys.getenv("GITHUB_PAT")

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -36,7 +36,17 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
-          files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          # `.token` is passed explicitly so gh skips its own PAT-format
+          # validation. The Actions runner now hands `secrets.GITHUB_TOKEN`
+          # as a `ghs_*` server-to-server token, which gh 1.5.0's
+          # `validate_gh_pat()` rejects outright (the fix for this lives
+          # in gh main / PR #233 but is not in any CRAN release yet, so
+          # bumping the pin is not an option). Bypassing validation works
+          # because Actions' token authenticates fine against the API.
+          files <- gh::gh(
+            "GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files",
+            .token = Sys.getenv("GITHUB_PAT")
+          )
           changed_files <- files |>
             purrr::keep(~ .$status != "renamed" || .$changes > 0) |>
             purrr::map_chr("filename")


### PR DESCRIPTION
## Summary

The `lint-changed-files` job has been failing on every recent PR (observed across three consecutive runs on #706) with:

```
Error in `validate_gh_pat()`:
! Invalid GitHub PAT format
ℹ A GitHub PAT must have one of three forms:
• 40 hexadecimal digits (older PATs)
• A 'ghp_' prefix followed by 36 to 251 more characters (newer PATs)
• A 'github_pat_' prefix followed by 36 to 244 more characters (fine-grained PATs)
```

GitHub Actions now hands `secrets.GITHUB_TOKEN` as a `ghs_*` server-to-server token, which `gh 1.5.0`'s `validate_gh_pat()` doesn't recognize. The validator aborts before any lint can run — `LINTR_ERROR_ON_LINT: true` then halts the script and the job exits 1. No lint findings ever existed; CI just couldn't reach the lint step.

## Fix

Pass `.token = Sys.getenv("GITHUB_PAT")` explicitly to `gh::gh()`. When `.token=` is supplied, `gh` uses it directly via the Authorization header and skips `validate_gh_pat()` entirely. The token authenticates fine against the API — the only issue was `gh`'s own format check.

## Why not bump the gh pin

The proper fix is [r-lib/gh#233](https://github.com/r-lib/gh/pull/233), merged into `gh` `main` on 2026-05-28. But the latest CRAN/tagged release is still **v1.5.0** (May 2025) — the fix has not yet shipped in a CRAN release, so bumping the renv pin isn't an option yet. Once a CRAN release containing #233 lands, swap this workaround for a clean `renv::install("gh"); renv::snapshot()`.

## Test plan

- [ ] `lint-changed-files` job goes green on this PR (and on every other open PR after merge).
- [ ] No behavioral change to lintr itself — same files linted, same config.

https://claude.ai/code/session_01PtDgktdMme5SZtze1EGx9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtDgktdMme5SZtze1EGx9U)_