### PR TITLE
Fix duplicate #def-iid anchor in probability.qmd

### DIFF
--- a/chapters/probability.qmd
+++ b/chapters/probability.qmd
@@ -1757,7 +1757,7 @@ A set of random variables $\dsn{X}$ are **independent and identically distribute
 
 ---
 
-:::{#def-iid}
+:::{#def-ciid}
 ### Conditionally independent and identically distributed
 
 A set of random variables $\dsn{Y}$ are **conditionally independent and identically distributed** (shorthand: "$Y_i | X_i\ \ciid$" or just "$Y_i |X_i\ \iid$") given a set of covariates $\dsn{X}$


### PR DESCRIPTION
While building the concept-map graph for #872, I scanned all callout ids and found one **genuine duplicate**: `probability.qmd` uses `#def-iid` for two *different* definitions —

- "Independent and identically distributed", and
- "**Conditionally** independent and identically distributed".

A duplicate `#id` makes any `@def-iid` cross-reference ambiguous (Quarto resolves to one of them arbitrarily). This renames the second (conditional) definition to `#def-ciid`.

There are **zero** `@def-iid` references in the notes, so no links need updating — this is a safe, self-contained fix.

## Context

This is the only real crossref defect found: a full scan of the notes shows **0 orphaned references** (every `@type-id` points to a real div). The "unable to resolve crossref" warnings seen when rendering a single chapter in isolation are just the single-chapter-render artifact — they resolve in the full book/website build.

## Checks

- `quarto render chapters/probability.qmd --to html` ✅
- `lintr` ✅ (0 findings)
- `spelling::spell_check_package()` ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)