### PR TITLE
Fix broken cross-references and brace-protect bib title capitalization

### DIFF
--- a/_subfiles/math-prereqs/_calc_integrals_ftc.qmd
+++ b/_subfiles/math-prereqs/_calc_integrals_ftc.qmd
@@ -45,11 +45,9 @@ $$\int_a^x \dif{F}{t}\,dt = F(x) - F(a)$$
 The two parts of the FTC together express that **differentiation and
 integration are inverse operations**:
 
-- Part 1: differentiating the integral of $f$ recovers $f$
-  (@eq-ftc-deriv-of-integral).
+- Part 1: differentiating the integral of $f$ recovers $f$ (@eq-ftc-deriv-of-integral).
 - Part 2: the integral of $f$ over $[a, b]$ equals the difference of
-  any antiderivative's values at the endpoints
-  (@eq-ftc-part2),
+  any antiderivative's values at the endpoints (@eq-ftc-part2),
   which rearranges to "integrating the derivative of $F$ recovers the
   net change in $F$" (@eq-ftc-integral-of-deriv).
 

--- a/_subfiles/math-prereqs/_sec_linear_algebra.qmd
+++ b/_subfiles/math-prereqs/_sec_linear_algebra.qmd
@@ -740,7 +740,7 @@ They occur frequently in statistics:
 - The residual sum of squares in linear regression
   (@sec-vector-calculus) is a quadratic form.
 - The variance of a linear combination of estimates
-  (@sec-linreg-inference) is a quadratic form:
+  (@sec-infer-LMs) is a quadratic form:
   $\Var{\tp{\vx}\hat{\vb}} = \tp{\vx}\,\Var{\hat{\vb}}\,\vx$.
 :::
 

--- a/_subfiles/math-prereqs/_sec_linear_algebra.qmd
+++ b/_subfiles/math-prereqs/_sec_linear_algebra.qmd
@@ -737,10 +737,10 @@ and $\matr{S}$ is a $p \times p$ matrix.
 Quadratic forms are the matrix generalizations of the scalar expression $c x^2$.
 They occur frequently in statistics:
 
-- The residual sum of squares in linear regression
-  (@sec-vector-calculus) is a quadratic form.
-- The variance of a linear combination of estimates
-  (@sec-infer-LMs) is a quadratic form:
+- The residual sum of squares in linear regression (@sec-vector-calculus)
+  is a quadratic form.
+- The variance of a linear combination of estimates (@sec-infer-LMs)
+  is a quadratic form:
   $\Var{\tp{\vx}\hat{\vb}} = \tp{\vx}\,\Var{\hat{\vb}}\,\vx$.
 :::
 

--- a/_subfiles/proportional-hazards-models/_sec-surv-conditional-hazards.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-surv-conditional-hazards.qmd
@@ -69,7 +69,7 @@ Now, let's define ***how*** the hazard function depends on covariates.
 We typically use a log link to model the relationship between
 the hazard function, $\haz(t|\vx)$, and
 the linear component, $\eta(t|\vx)$,
-as we did for Poisson models in [models for count outcomes](count-regression.qmd#sec-count-reg);
+as we did for Poisson models in [models for count outcomes](count-regression.qmd);
 that is:
 
 :::

--- a/chapters/basic-statistical-methods.qmd
+++ b/chapters/basic-statistical-methods.qmd
@@ -556,7 +556,7 @@ fisher.test(hers$exercise, hers$HT)
 
 ## Measures of association for 2×2 tables {#sec-2x2-measures}
 
-See [Odds Ratios and Relative Risks](OR-RR.qmd) for definitions and formulas.
+See [Odds Ratios and Relative Risks](logistic-regression.qmd#sec-OR-RR) for definitions and formulas.
 
 # Correlation {#sec-correlation}
 

--- a/chapters/inference.qmd
+++ b/chapters/inference.qmd
@@ -27,7 +27,7 @@ based on the data (and our prior beliefs).
 
 There are two predominant paradigms for statistical inference:
 
-1. [Bayesian inference](intro-bayes.qmd#sec-bayes)
+1. [Bayesian inference](intro-bayes.qmd)
 2. [Frequentist inference](intro-MLEs.qmd#sec-intro-MLEs)
 
 # Interpretation of Negative Findings
@@ -68,7 +68,7 @@ To do: convert this sketch into a nicely formatted figure.
 
 See also @vittinghoff2e §3.7 (p64).
 
-# Confidence intervals
+# Confidence intervals {#sec-CI}
 
 :::{#def-margin-error}
 ## margin of error

--- a/chapters/intro-MLEs.qmd
+++ b/chapters/intro-MLEs.qmd
@@ -20,7 +20,7 @@ Some material was also taken from @mclachlan2007em and @CaseBerg01.
 
 {{< include shared-config.qmd >}}
 
-# Overview of maximum likelihood estimation
+# Overview of maximum likelihood estimation {#sec-intro-MLEs}
 
 {{< include _subfiles/intro-MLEs/_sec_likelihood.qmd >}}
 

--- a/references.bib
+++ b/references.bib
@@ -100,7 +100,7 @@
 }
 
 @article{Grodstein2001,
-  title={Postmenopausal hormone use and secondary prevention of coronary events in the Nurses' Health Study: a prospective, observational study},
+  title={Postmenopausal hormone use and secondary prevention of coronary events in the {Nurses' Health Study}: a prospective, observational study},
   author={Grodstein, Francine and Manson, JoAnn E. and Stampfer, Meir J. and Colditz, Graham A. and Willett, Walter C. and Rosner, Bernard and Speizer, Frank E. and Hennekens, Charles H.},
   journal={Annals of Internal Medicine},
   year={2001},
@@ -121,7 +121,7 @@
 }
 
 @article{Vittinghoff2003,
-  title={Risk factors and secondary prevention in women with heart disease: the Heart and Estrogen/progestin Replacement Study},
+  title={Risk factors and secondary prevention in women with heart disease: the {Heart and Estrogen/progestin Replacement Study}},
   author={Vittinghoff, Eric and Shlipak, Michael G. and Varosy, Peter D. and McDermott, Mary and Robbins, John A. and Harris, Tamara B. and Newman, Anne B. and Bauer, Douglas C.},
   journal={Annals of Internal Medicine},
   year={2003},
@@ -202,7 +202,7 @@
 }
 
 @book{mclachlan2007em,
-  title={The EM algorithm and extensions},
+  title={The {EM} algorithm and extensions},
   author={McLachlan, Geoffrey J and Krishnan, Thriyambakam},
   year={2007},
   edition={2},
@@ -276,7 +276,7 @@ eprint = {https://www.aerzteblatt.de/pdf.asp?id=222631}
 }
 
 @article{efron1978assessing,
-  title={Assessing the accuracy of the maximum likelihood estimator: Observed versus expected Fisher information},
+  title={Assessing the accuracy of the maximum likelihood estimator: Observed versus expected {Fisher} information},
   author={Efron, Bradley and Hinkley, David V},
   journal={Biometrika},
   volume={65},
@@ -434,7 +434,7 @@ eprint = {https://www.aerzteblatt.de/pdf.asp?id=222631}
   }
 
 @article{anderson1935irises,
-  title={The irises of the Gaspe Peninsula},
+  title={The irises of the {Gaspe Peninsula}},
   author={Anderson, Edgar},
   journal={Bulletin of American Iris Society},
   volume={59},
@@ -608,7 +608,7 @@ doi={10.1007/978-1-0716-1282-8}
 }
 
 @book{kleinman2009sas,
-  title={SAS and R: Data management, statistical analysis, and graphics},
+  title={SAS and {R}: Data management, statistical analysis, and graphics},
   author={Kleinman, Ken and Horton, Nicholas J},
   year={2009},
   publisher={Chapman and Hall/CRC},
@@ -652,7 +652,7 @@ doi={10.1007/978-1-0716-1282-8}
 }
 
 @article{rosenman1975coronary,
-  title={Coronary heart disease in the Western Collaborative Group Study: Final follow-up experience of 8 1/2 years},
+  title={Coronary heart disease in the {Western Collaborative Group Study}: Final follow-up experience of 8 1/2 years},
   author={Rosenman, Ray H and Brand, Richard J and Jenkins, C David and Friedman, Meyer and Straus, Reuben and Wurm, Moses},
   journal={JAMA},
   volume={233},
@@ -749,7 +749,7 @@ doi={10.1007/978-1-0716-1282-8}
 }
 
 @article{copelan1991treatment,
-  title={Treatment for acute myelocytic leukemia with allogeneic bone marrow transplantation following preparation with BuCy2},
+  title={Treatment for acute myelocytic leukemia with allogeneic bone marrow transplantation following preparation with {BuCy2}},
   author={Copelan, Edward A and Biggs, James C and Thompson, James M and Crilley, Pamela and Szer, Jeff and Klein, John P and Kapoor, Neena and Avalos, Belinda R and Cunningham, Isabel and Atkinson, Kerry},
   year={1991},
   doi={10.1182/blood.V78.3.838.838}
@@ -882,7 +882,7 @@ doi={10.1007/978-1-0716-1282-8}
 }
 
 @book{muenchen2011r,
-  title={R for SAS and SPSS users},
+  title={R for {SAS} and {SPSS} users},
   author={Muenchen, Robert A},
   year={2011},
   publisher={Springer Science \& Business Media},
@@ -911,7 +911,7 @@ doi={10.1007/978-1-0716-1282-8}
 }
 
 @article{aragon2018population,
-  title={Population health thinking with Bayesian networks},
+  title={Population health thinking with {Bayesian} networks},
   author={Aragon, Tomas J},
   year={2018},
   url={https://escholarship.org/uc/item/8000r5m5}
@@ -1381,14 +1381,14 @@ url = {https://press.princeton.edu/books/paperback/9780691172934/the-real-analys
 @book{kery-bayes-pop,
 author = {Kéry, Marc. and Schaub, Michael. and Beissinger, Steven R.},
 address = {Boston},
-booktitle = {Bayesian population analysis using WinBUGS : a hierarchical perspective},
+booktitle = {Bayesian population analysis using {WinBUGS} : a hierarchical perspective},
 edition = {1st ed.},
 isbn = {9786613272829},
 keywords = {Population biology -- Data processing ; R (Computer program language) ; WinBUGS},
 language = {eng},
 lccn = {2011029641},
 publisher = {Academic Press},
-title = {Bayesian population analysis using WinBUGS : a hierarchical perspective },
+title = {Bayesian population analysis using {WinBUGS} : a hierarchical perspective },
 year = {2012},
 url={https://shop.elsevier.com/books/bayesian-population-analysis-using-winbugs/kery/978-0-12-387020-9}
 }
@@ -1427,7 +1427,7 @@ year = {2015},
 @book{statrethink2e,
 author = {McElreath, Richard},
 address = {Boca Raton, FL},
-booktitle = {Statistical rethinking : a Bayesian course with examples in {R} and {Stan}},
+booktitle = {Statistical rethinking : a {Bayesian} course with examples in {R} and {Stan}},
 edition = {Second edition},
 isbn = {036713991X},
 keywords = {Théorie de la décision bayésienne ; R (Langage de programmation) ; Théorème de Bayes ; Logiciels ; software ; Computer software ; Computer programs ; Bayesian statistical decision theory ; R (Computer program language) ; Bayes-Entscheidungstheorie ; R Programm ; Statistisches Modell ; Mathematics},

--- a/references.bib
+++ b/references.bib
@@ -608,7 +608,7 @@ doi={10.1007/978-1-0716-1282-8}
 }
 
 @book{kleinman2009sas,
-  title={SAS and {R}: Data management, statistical analysis, and graphics},
+  title={{SAS} and {R}: Data management, statistical analysis, and graphics},
   author={Kleinman, Ken and Horton, Nicholas J},
   year={2009},
   publisher={Chapman and Hall/CRC},


### PR DESCRIPTION
Global cleanup split off from the count-regression work (per request to keep these separate from the per-chapter PRs).

## Broken cross-references (from a whole-book audit)

| Was | Now | Why |
|---|---|---|
| `@sec-linreg-inference` | `@sec-infer-LMs` | anchor never existed; `sec-infer-LMs` is the LM-inference section |
| `intro-MLEs.qmd#sec-intro-MLEs` (×2) | added `{#sec-intro-MLEs}` to the intro-MLEs H1 | page existed, anchor didn't |
| `inference.qmd#sec-CI` | added `{#sec-CI}` to "Confidence intervals" | page existed, anchor didn't |
| `intro-bayes.qmd#sec-bayes` | bare `intro-bayes.qmd` | no such anchor; link targets the chapter |
| `count-regression.qmd#sec-count-reg` | bare `count-regression.qmd` | no such anchor |
| `OR-RR.qmd` | `logistic-regression.qmd#sec-OR-RR` | root `OR-RR.qmd` is an orphan, never rendered |

## Bibliography capitalization

Brace-protected letters that must stay capitalized in sentence-case titles so sentence-case citation styles don't lowercase them: acronyms (`{EM}`, `{SAS}`, `{SPSS}`, `{WinBUGS}`), software/proper nouns (`{R}`, `{BuCy2}`, `{Fisher}`, `{Bayesian}`), and named studies (`{Nurses' Health Study}`, `{Heart and Estrogen/progestin Replacement Study}`, `{Western Collaborative Group Study}`, `{Gaspe Peninsula}`).

## Not in this PR (handled on their own branches)
- The `poisson.qmd#def-offset` link and the `tsui2009hcv` "hepatitis {C}" fix live on the count-regression PR (#860), where those entries exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)