### PR TITLE
Fix lint-changed-files: use gh CLI instead of gh R package for changed-file list

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -34,16 +34,33 @@ jobs:
           cat('\noptions(lintr.linter_file = ".lintr")\n', file = "~/.Rprofile", append = TRUE)
         shell: Rscript {0}
 
-      - name: Extract and lint files changed by this PR
+      # Use the `gh` CLI (not the gh R package) to list changed files. The R
+      # package resolves the token via gitcreds and rejected the Actions token
+      # with "Invalid GitHub PAT format"; the CLI reads GH_TOKEN directly and
+      # handles the `ghs_` Actions token format natively.
+      - name: Extract files changed by this PR
         run: |
-          files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
-          changed_files <- files |>
-            purrr::keep(~ .$status != "renamed" || .$changes > 0) |>
-            purrr::map_chr("filename")
+          gh api \
+            --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[] | select(.status != "renamed" or .changes > 0) | .filename' \
+            > changed_files.txt
+          echo "Changed files:"
+          cat changed_files.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint files changed by this PR
+        run: |
+          changed_files <- readLines("changed_files.txt")
           changed_files <- setdiff(changed_files, "renv/activate.R")
-          all_files <- list.files(recursive = TRUE)
-          exclusions_list <- as.list(setdiff(all_files, changed_files))
-          lintr::lint_dir(exclusions = exclusions_list)
+          if (length(changed_files) == 0) {
+            message("No changed files to lint.")
+          } else {
+            all_files <- list.files(recursive = TRUE)
+            exclusions_list <- as.list(setdiff(all_files, changed_files))
+            lintr::lint_dir(exclusions = exclusions_list)
+          }
         shell: Rscript {0}
         env:
           LINTR_ERROR_ON_LINT: true


### PR DESCRIPTION
## Problem

The `lint-changed-files` workflow has been failing on PRs (e.g. #881) **before it lints anything**, with:

```
Error in `validate_gh_pat()`:
! Invalid GitHub PAT format
Backtrace:
  1. gh::gh("GET .../pulls/881/files")
  ...
  7. gh::gh_token(api_url)
  8. gh:::gh_pat(token$password %||% "")
  9. gh:::validate_gh_pat(new_gh_pat(x))
```

The step used the **gh R package** to list a PR's changed files. `gh::gh()` doesn't use the job's `GITHUB_PAT` env directly — it resolves a token via `gitcreds`, and the credential it gets back in CI is rejected as a malformed PAT. The job aborts at the API call, so `lintr` never runs and every PR shows a red check that has nothing to do with the code.

(Confirmed not a lint finding: local `lintr::lint()` on changed files passes; the failure is purely token resolution in the R `gh` package.)

## Fix

List the changed files with the preinstalled **`gh` CLI** instead. `gh api` reads `GH_TOKEN` directly and accepts the `ghs_` Actions-token format, sidestepping the R package's gitcreds path entirely:

- New **Extract** step: `gh api --paginate repos/…/pulls/N/files --jq '.[] | select(.status != "renamed" or .changes > 0) | .filename' > changed_files.txt` (with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`).
- New **Lint** step (R): reads `changed_files.txt`, drops `renv/activate.R`, and runs `lintr::lint_dir()` with all other files excluded — now guarding the empty-list case.

The `--jq` filter reproduces the original `purrr::keep(~ .$status != "renamed" || .$changes > 0)` semantics exactly (verified: renamed-with-0-changes excluded, renamed-with-changes and all non-renamed included). `--paginate` handles PRs with many files.

No change to which files get linted or to the lint config — only how the changed-file list is obtained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)