### PR TITLE
Fix \exp macro misuse breaking PDF render

### DIFF
--- a/chapters/midterm-2-review-session.qmd
+++ b/chapters/midterm-2-review-session.qmd
@@ -133,7 +133,7 @@ Two versions of this error were common:
    hazards $\hat\lambda_j = d_j / n_j$.
 
 2. Computing the cumulative hazard correctly but then forgetting the final
-   step, $\hat S_{NA}(t) = \exp\{-\hat\Lambda(t)\}$, and reporting the
+   step, $\hat S_{NA}(t) = \exp{-\hat\Lambda(t)}$, and reporting the
    cumulative hazard itself (or the KM product) as the Nelson-Aalen survival
    estimate.
 :::
@@ -145,15 +145,15 @@ instantaneous hazard contributions at each event time:
 $$\hat\Lambda(t) = \sum_{j: t_j \le t} \frac{d_j}{n_j}$$
 
 and then converts it to a survival estimate using
-$\surv(t) = \exp\{-\cumhaz(t)\}$:
+$\surv(t) = \exp{-\cumhaz(t)}$:
 
-$$\hat S_{NA}(t) = \exp\left\{-\hat\Lambda(t)\right\}$$
+$$\hat S_{NA}(t) = \exp{-\hat\Lambda(t)}$$
 
 For example, at $t = 10$:
 
 $$\hat\Lambda(10) = \frac{1}{7} = 0.143,
 \qquad
-\hat S_{NA}(10) = \exp\{-0.143\} = 0.867$$
+\hat S_{NA}(10) = \exp{-0.143} = 0.867$$
 
 Contrast this with Kaplan-Meier, which multiplies conditional survival
 probabilities:
@@ -330,7 +330,7 @@ $$\Lik_i \propto \left[\f(y_i \mid \tilde x_i)\right]^{d_i}
 
 **Distribution functions** (define each one):
 
-$$\surv(t \mid \tilde x) \eqdef \P(T > t \mid \tilde X = \tilde x) = \exp\left\{-\cumhaz(t \mid \tilde x)\right\}$$
+$$\surv(t \mid \tilde x) \eqdef \P(T > t \mid \tilde X = \tilde x) = \exp{-\cumhaz(t \mid \tilde x)}$$
 
 $$\f(t \mid \tilde x) \eqdef \haz(t \mid \tilde x)\,\surv(t \mid \tilde x)$$
 
@@ -349,7 +349,7 @@ where $\lambda_0(t)$ is the **unspecified** baseline hazard.
 of a linear predictor):
 $$\loghaz(t \mid \tilde x) = \loghaz_0(t) + \Delta\loghaz(\tilde x),
 \qquad
-\theta(\tilde x) = \exp\left\{\Delta\loghaz(\tilde x)\right\}$$
+\theta(\tilde x) = \exp{\Delta\loghaz(\tilde x)}$$
 
 ***Linear functional-form assumption*** (used to write the covariate term as a
 linear combination):
@@ -416,12 +416,12 @@ table reporting the HR per **decade**), the errors were:
 On the **log** scale, the effect is linear: a change of $c$ units multiplies the
 log-hazard by $c \cdot \beta$. So the hazard ratio for a $c$-unit change is
 
-$$HR(c) = \exp\{c\,\beta\} = \left(\exp\{\beta\}\right)^c = HR^{\,c}$$
+$$HR(c) = \exp{c\,\beta} = \left(\exp{\beta}\right)^c = HR^{\,c}$$
 
 A 7.5-year increase is $c = 0.75$ decades, and the per-decade
 $\widehat{HR} = 1.94$ (i.e. $\hat\beta_A = \log 1.94 = 0.66$):
 
-$$\widehat{HR}(0.75) = 1.94^{\,0.75} = \exp\{0.75 \times 0.66\} = \exp\{0.495\} = 1.64$$
+$$\widehat{HR}(0.75) = 1.94^{\,0.75} = \exp{0.75 \times 0.66} = \exp{0.495} = 1.64$$
 
 So a 7.5-year-older man has about **64% higher** estimated hazard of CHD, all
 else equal. The operation is **exponentiation** ($HR^{0.75}$), not
@@ -537,12 +537,12 @@ hypothesis test agree.
 | # | Exam Q | Topic | The fix |
 |:-:|:------:|:------|:--------|
 | 1 | 1.1 | Risk set after censoring (@sec-risk-set) | Remove **everyone** who has an event *or* is censored from later risk sets. |
-| 2 | 1.1 | Nelson-Aalen (@sec-na-exp) | Sum hazards $d_j/n_j$, then $\hat S_{NA} = \exp\{-\hat\Lambda\}$. |
+| 2 | 1.1 | Nelson-Aalen (@sec-na-exp) | Sum hazards $d_j/n_j$, then $\hat S_{NA} = \exp{-\hat\Lambda}$. |
 | 3 | 1.3 | Reading $\hat S(t)$ (@sec-step-function) | Step function: use the most recent event time $\le t$; give the number. |
 | 4 | 1.4 | Median survival (@sec-median) | First $t$ with $\hat S(t) \le 0.5$ — not a mean, not an exponential fit. |
 | 5 | 1.5 | Role of censoring (@sec-censoring-role) | Denominator until censoring; never the event numerator. |
 | 6 | 2.1 | Writing the model (@sec-write-model) | Name **and** apply every assumption; baseline hazard stays unspecified. |
 | 7 | 2.2 | Interpreting an HR (@sec-interpret) | Magnitude + reference + adjustment + significance; HR $\ne$ risk/odds. |
-| 8 | 2.3 | HR for a non-unit change (@sec-hr-multiunit) | $HR^{\,c} = \exp\{c\beta\}$ — exponentiate, don't multiply. |
+| 8 | 2.3 | HR for a non-unit change (@sec-hr-multiunit) | $HR^{\,c} = \exp{c\beta}$ — exponentiate, don't multiply. |
 | 9 | 2.4 | Comparing two coefficients (@sec-wald) | $\V(\hat\beta_H - \hat\beta_L) = \V_H + \V_L - 2\,\Covt$. |
 | 10 | 2.5 | CI for an HR (@sec-ci-hr) | Build on the log scale, then exponentiate the endpoints. |


### PR DESCRIPTION
The \exp macro already wraps its argument in braces (\operatorname{exp}\cb{#1}), so \exp\left\{...\right\} and \exp\{...\} fed the leading \left / \{ token as the macro argument, producing \operatorname{exp}\left\{\left\right\}... — a missing-delimiter lualatex error that aborted the book build, plus pandoc "Could not convert TeX math" warnings.

Use the correct \exp{...} form throughout the Midterm 2 review chapter.