### PR TITLE
Make @claude file-edit tools explicit in allowed-tools list

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -295,9 +295,9 @@ jobs:
           # replacement — which is why prior @claude runs committed file
           # edits fine (e.g. claude[bot] commit 05318e02 on PR #843).
           #
-          # We still list Edit/Write/MultiEdit explicitly because a
-          # session that inspects its own --allowed-tools string and sees
-          # only Bash/gh/git/WebFetch entries can wrongly conclude file
+          # We still list the file tools explicitly because a session
+          # that inspects its own --allowed-tools string and sees only
+          # Bash/gh/git/WebFetch entries can wrongly conclude file
           # editing is disallowed and bail out — posting its diff as a
           # comment instead of committing it (PR #843 run 27032044840,
           # 2026-06-05: a 27-min session designed probability-based
@@ -306,7 +306,11 @@ jobs:
           # session's --allowed-tools list"). Naming the tools here makes
           # the grant unambiguous in the string the agent can see, and
           # guards against the action's additive behaviour ever changing.
-          FILE_TOOLS="Edit,Write,MultiEdit"
+          # Read/Glob/Grep are listed alongside the write tools so the
+          # same allowlist-inspection logic can't talk a session out of
+          # reading or searching files either (they're read-only and,
+          # like the edit tools, already allowed by default).
+          FILE_TOOLS="Read,Glob,Grep,Edit,Write,MultiEdit"
           if [ -n "$WEBFETCH" ]; then
             echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${FILE_TOOLS},${GH_TOOLS},${GIT_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -287,10 +287,30 @@ jobs:
           #   (allowed below) already reports the current branch name,
           #   covering the only legitimate read-only use case.
           GIT_TOOLS="Bash(git add *),Bash(git commit *),Bash(git rm *),Bash(git mv *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git show*),Bash(git restore *),Bash(git checkout -- *)"
+          # File-editing tools. claude-code-action ALREADY allows file
+          # reads/edits by default (see the action's configuration docs:
+          # "By default, Claude only has access to: File operations
+          # (reading, committing, editing files, ...)"), and `claude_args
+          # --allowed-tools` is ADDITIVE to that default rather than a
+          # replacement — which is why prior @claude runs committed file
+          # edits fine (e.g. claude[bot] commit 05318e02 on PR #843).
+          #
+          # We still list Edit/Write/MultiEdit explicitly because a
+          # session that inspects its own --allowed-tools string and sees
+          # only Bash/gh/git/WebFetch entries can wrongly conclude file
+          # editing is disallowed and bail out — posting its diff as a
+          # comment instead of committing it (PR #843 run 27032044840,
+          # 2026-06-05: a 27-min session designed probability-based
+          # example rewrites, then declined to apply them claiming
+          # "Edit/Write require approval not configured in the current
+          # session's --allowed-tools list"). Naming the tools here makes
+          # the grant unambiguous in the string the agent can see, and
+          # guards against the action's additive behaviour ever changing.
+          FILE_TOOLS="Edit,Write,MultiEdit"
           if [ -n "$WEBFETCH" ]; then
-            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS},${GIT_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
+            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${FILE_TOOLS},${GH_TOOLS},${GIT_TOOLS},${WEBFETCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${GH_TOOLS},${GIT_TOOLS}" >> "$GITHUB_OUTPUT"
+            echo "allowed=Bash(Rscript *),Bash(quarto *),Bash(curl *),${FILE_TOOLS},${GH_TOOLS},${GIT_TOOLS}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Claude Code


### PR DESCRIPTION
## Problem

On PR #843 ([run 27032044840](https://github.com/d-morrison/rme/actions/runs/27032044840)), the `@claude` agent ran a successful 27-min session that designed probability-based rewrites for two worked examples, then **declined to commit them**, claiming *"Edit/Write require approval not configured in the current session's `--allowed-tools` list."*

That diagnosis was wrong. Per [`claude-code-action`'s configuration docs](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md), file editing is allowed **by default** and `claude_args --allowed-tools` is **additive** (it grants Bash/gh/git/WebFetch commands *on top of* the built-in file tools). `claude[bot]` has in fact committed file edits through this exact workflow before (commit `05318e02`). The session simply read its own allowlist string, saw no `Edit` entry, and talked itself out of editing.

## Fix

List `Edit,Write,MultiEdit` explicitly in the allowed-tools string the agent sees, so a future session can't misread the allowlist and bail. Redundant given the action's current additive behaviour, but it removes the ambiguity that caused the bail-out and guards against that behaviour ever changing. A comment records the why.

No load-bearing pieces touched (bot-actor filter, concurrency, polling prompt, SHA capture, stats-allowlist regex, read-only `gh` subset all unchanged). YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)