### PR TITLE
Number examples: flip exm.override-title to false

### DIFF
--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -162,7 +162,7 @@ callouty-theorem:
       type: def
       appearance: minimal
   exm:
-    override-title: true
+    override-title: false
     callout:
       type: exm
       appearance: default


### PR DESCRIPTION
## Problem

`exm` examples render as **un-numbered** collapsible callouts titled "Example (heading)", while `def`/`thm`/etc. render as proper numbered crossrefs ("Definition 38 (Constant)", "Theorem 52 (…)"). So `@exm-…` references and example captions never get a number.

## Root cause

In the `callouty-theorem:` block of `_quarto-website.yml`, `exm` was the only numbered-theorem-style type set to **`override-title: true`**. That flag routes the div through the filter's static-title branch (`_extensions/d-morrison/callouty-theorem/callouty-theorem.lua:153-172`), which stamps a fixed `"Example"` label + the div heading and **bypasses Quarto's native `quarto.Theorem` numbering**. All the numbered types (`thm`, `def`, `lem`, `cor`, `prp`, `cnj`, `exr`) use `override-title: false`.

## Fix

Set `exm.override-title: false` so examples route through `quarto.Theorem` like the other types and render the numbered, auto-labeled **"Example N (name)"** heading in the same purple example callout.

No example headings on `main` begin with a redundant "Example" label (checked all 100 `{#exm-}` divs), so no heading edits are needed here.

## Verification

`quarto render chapters/math-prereqs.qmd --to html --profile website`:
- before: 0 examples numbered
- after: **14/14** render as "Example N (…)" (e.g. "Example 3 (Antiderivative of a power function)")

## Notes

- Global rendering change (re-numbers all examples book-wide) → **clear freezer** label applied.
- Pre-existing unrelated warning `Unable to resolve crossref @sec-infer-LMs` is not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)