### PR TITLE
Make @claude prompt demand a commit before finishing

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -523,9 +523,8 @@ jobs:
                tree and will be discarded. Treat this as a task
                failure: commit the work, or if you've decided not to
                change anything, say so explicitly in your final
-               comment ("no changes
-               needed because X") rather than describing edits that
-               weren't committed.
+               comment ("no changes needed because X") rather than
+               describing edits that weren't committed.
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -386,6 +386,12 @@ jobs:
               (`issue_comment` fires for both issues and PRs; this
               flag disambiguates without you guessing.)
             - Entity number: `${{ github.event.issue.number || github.event.pull_request.number }}`
+            - Session-start SHA (the tip of the branch when your
+              session started): `${{ steps.head_before.outputs.sha || steps.issue_branch.outputs.starting_sha }}`
+              For PR triggers this is the PR head before you ran; for
+              issue triggers it's the tip of the freshly-created
+              `claude/issue-N-<timestamp>` branch. Use it as the base
+              for the step-5 commit-presence check below.
 
             - **PR triggers** (`issue_comment` on a PR,
               `pull_request_review`, `pull_request_review_comment`):
@@ -500,22 +506,24 @@ jobs:
                someone pushed by hand.
 
             5. **Pre-finish self-check (mandatory).** Immediately
-               before you stop, run these and verify the output:
+               before you stop, run these and verify the output
+               (substitute the Session-start SHA from the context
+               block above for `<START>`):
 
                ```
-               git status --porcelain   # MUST be empty
-               git log --oneline -5     # confirm your commits are present
+               git status --porcelain         # MUST be empty
+               git log --oneline <START>..HEAD   # check whether you committed
                ```
 
                If `git status --porcelain` shows ANY output, you have
                uncommitted edits — stage and commit them before
-               stopping. If you intended to make code changes but
-               `git log` shows no new commits on top of the branch
-               you started on, you have NOT done the task — the
-               edits live only in the working tree and will be
-               discarded. Treat this as a task failure: commit the
-               work, or if you've decided not to change anything,
-               say so explicitly in your final comment ("no changes
+               stopping. If you intended to make code changes but the
+               `git log <START>..HEAD` range is empty, you have NOT
+               done the task — the edits live only in the working
+               tree and will be discarded. Treat this as a task
+               failure: commit the work, or if you've decided not to
+               change anything, say so explicitly in your final
+               comment ("no changes
                needed because X") rather than describing edits that
                weren't committed.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -418,13 +418,24 @@ jobs:
                so and exit, and the next workflow run will pick up
                from there via the serialize-per-PR concurrency group.
 
-            4. Commit all changes before finishing. `git add`,
-               `git commit`, `git rm`, and read-only git inspection
-               commands are in your allowed-tools list; `git push`
-               is NOT. A post-Claude workflow step pushes:
-               - For PR triggers, your commits are already on the
-                 PR's head branch — the post-step re-requests review
-                 and dispatches code review when the head SHA moves.
+            4. **Commit all changes before finishing — this is the
+               single most common way these runs silently fail.**
+               Editing files with Edit/Write changes the working tree
+               but does NOT change the git history; only `git add` +
+               `git commit` does. If you describe work as "done" in a
+               comment but never committed, the post-step sees the
+               PR head SHA unchanged and your work is lost when the
+               runner is reclaimed. The user has no way to recover it.
+
+               `git add`, `git commit`, `git rm`, and read-only git
+               inspection commands are in your allowed-tools list;
+               `git push` is NOT, and any attempt to call it will
+               fail with a permission denial. **Do not attempt
+               `git push`** — a post-Claude workflow step performs
+               the push for you:
+               - For PR triggers, your commits go on the PR's head
+                 branch — the post-step re-requests review and
+                 dispatches code review when the head SHA moves.
                - For issue triggers, the workflow pre-creates a
                  `claude/issue-N-<timestamp>` branch and checks it
                  out before your session starts; the post-step
@@ -435,6 +446,26 @@ jobs:
                The concurrency group guarantees no parallel session
                is racing yours, so the push should succeed unless
                someone pushed by hand.
+
+            5. **Pre-finish self-check (mandatory).** Immediately
+               before you stop, run these and verify the output:
+
+               ```
+               git status --porcelain   # MUST be empty
+               git log --oneline -5     # confirm your commits are present
+               ```
+
+               If `git status --porcelain` shows ANY output, you have
+               uncommitted edits — stage and commit them before
+               stopping. If you intended to make code changes but
+               `git log` shows no new commits on top of the branch
+               you started on, you have NOT done the task — the
+               edits live only in the working tree and will be
+               discarded. Treat this as a task failure: commit the
+               work, or if you've decided not to change anything,
+               say so explicitly in your final comment ("no changes
+               needed because X") rather than describing edits that
+               weren't committed.
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,10 @@ Before committing any `.qmd`, `.R`, or config file change:
 
 ### Pull Requests
 - Remove existing review requests immediately when starting work on a PR
-- Ensure branch is up to date with `main` before requesting review
+- Always merge `main` into the feature branch before pushing — not just before requesting review
 - Verify all changed hyperlinks before requesting review
 - If any `_subfiles/` were edited, add the "clear freezer" label
+- Workflow / `.github/` / CI / infra changes go in their own dedicated PRs — never mix them with book-content PRs
 
 ## Workflow Responsibility
 


### PR DESCRIPTION
## Summary

- Sharpens step 4 of the `@claude` action prompt in `.github/workflows/claude.yml` to make explicit that uncommitted working-tree edits are lost when the runner exits, and that "I edited files" is not the same as "I committed".
- Adds a mandatory step 5 self-check: before stopping, run `git status --porcelain` (must be empty) and `git log --oneline -5` (must show the new commits). If nothing was committed, either commit or explicitly say "no changes needed" — describing edits that weren't committed is a task failure.
- Makes the `git push` exclusion louder so a denied push doesn't lead Claude to wrap up before committing.

## Why

Run [27045987736](https://github.com/d-morrison/rme/actions/runs/27045987736/job/79831924290) on PR #896 finished with `subtype: success`, `permission_denials_count: 1`, and `SHA_BEFORE == SHA_AFTER`. Claude used Edit/Write to modify files and posted a "Done. Here's a summary of what I implemented" comment, but never invoked `git add` + `git commit` — so the post-step correctly fell through to the prose-post path and the edits were discarded with the runner. The fix is in the prompt, not the permission model: keeping `git push` out of Claude's hands remains the right design.

## Test plan

- [ ] Trigger an `@claude` mention on a PR that requires file edits and confirm the new commits land on the PR head.
- [ ] Trigger an `@claude` mention where no edits are needed and confirm Claude says so explicitly rather than describing edits.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PtDgktdMme5SZtze1EGx9U)_