### PR TITLE
Make headless-Chrome startup reliable for PDF builds

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -4,3 +4,9 @@ if (interactive()) {
   require(usethis)
   require(devtools)
 }
+
+# Give headless Chrome more time to open its debugging port when `webshot2`
+# screenshots the interactive `plotly` figures during the PDF book build.
+# The chromote default waits only 10 seconds, which intermittently times out
+# under CI load ("Chrome debugging port not open after 10 seconds").
+options(chromote.timeout = 60)


### PR DESCRIPTION
## Problem

The `Quarto Publish` workflow ([run 402](https://github.com/d-morrison/rme/actions/runs/27047638453/job/79836765077)) failed during the **PDF build** of `probability.qmd`. While rendering the interactive `plotly` figures (the Fubini examples) to static images for PDF, `webshot2`/`chromote` could not launch headless Chrome:

```
Error in `startup()`: Chrome debugging port not open after 10 seconds.
...
Quitting from probability.qmd:3916-3944 [unnamed-chunk-1]
```

This is **intermittent CI infra flakiness, not a content bug**: the surrounding publish runs (396–401) render the identical `plotly` content successfully, while 402 (and earlier 393–395) died on Chrome startup. Under CI load, Chrome occasionally needs more than chromote's default **10-second** wait to open its debugging port.

## Fix

Raise `options(chromote.timeout = 60)` in the project-level `.Rprofile`, so the longer wait applies to every render session. `chromote.timeout` is read directly via `getOption("chromote.timeout", 10)`, so setting it is a plain option assignment — no package is loaded and no other session (lint/spell/check/interactive) is affected.

### Notes on the approach
- **Located in `.Rprofile`, not a chapter.** Keeps the change out of book content, so it doesn't trigger the full-file `lint-changed-files` check on the (pre-existing) lint debt in `chapters/r-config.qmd`.
- **Timeout only — no Chrome flags.** An earlier revision also set `--no-sandbox`/`--disable-dev-shm-usage` via `chromote::set_chrome_args()`. That was dropped: the failure presents as an intermittent *timeout* (a startup race), which the timeout bump targets directly, and dropping it avoids loading the `chromote` namespace into every R session. This also resolves the `claude-review` notes on the earlier revision (unconditional `--no-sandbox`; additive flag accumulation).

## Testing

⚠️ Neither R nor Quarto is available in this remote execution container, so I could **not** run a local render.

Note that the PR-level `Quarto Preview` (`build-deploy`) renders **HTML only** unless the PR carries the `preview:pdf` label, and its `paths:` filter doesn't include `.Rprofile`, so it does not exercise the failing PDF path for this change. The failing path lives in `publish.yml` (`push: branches: main`, `tinytex: true`), which has no `paths:` filter — so the `.Rprofile` timeout will take effect there on merge. The change is a one-line option set targeting the exact error message.

This PR contains only the rendering-reliability fix (no book content), per the convention that infra changes live in their own dedicated PR.

https://claude.ai/code/session_016BZ7qTv61H73FCGo5H7cjr