### PR TITLE
claude-code-review: run on Claude-bot pushes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,9 +39,15 @@ on:
 # SAME expression as the job `if:`: a run only cancels in-progress
 # peers when it would itself actually run. (Keep this expression in
 # sync with the job `if:` below.)
+#
+# Note: the job `if:` now also runs on Claude-bot pushes (actor
+# `claude` / `claude[bot]`) — see the rationale on the job below.
+# Those runs therefore legitimately cancel an in-progress peer so the
+# freshest diff wins; this is recursion-safe because the reviewer is
+# review-only and can never push a `synchronize`-triggering commit.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]')) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]')) || github.actor == 'claude' || github.actor == 'claude[bot]' }}
 
 jobs:
   claude-review:
@@ -53,12 +59,35 @@ jobs:
     # stuck on whatever verdict was generated when they were first opened.
     # See d-morrison/rme#801 for the original symptom report.
     #
+    # Exception to the bot-actor filter: a push from the Claude bot
+    # SHOULD be reviewed. Claude Code on the web and the @claude agent
+    # commit under the `claude` user account (login `claude`, id 81847,
+    # noreply@anthropic.com); pushes made through the Claude GitHub App
+    # surface as actor `claude[bot]`. Either way these are AI-authored
+    # commits — exactly the ones we most want a second pass over — yet
+    # the generic `endsWith(actor, '[bot]')` / `sender.type == 'Bot'`
+    # rule above was silently skipping them. The two clauses added below
+    # opt those pushes back in.
+    #
+    # This is safe from the self-trigger / frozen-comment recursion that
+    # originally motivated skipping bot pushes (see the concurrency
+    # comment above re: PR #809). This workflow is review-ONLY: the
+    # `--disallowedTools "Bash(git commit:*)" …` list on the review step
+    # means the reviewer can never commit, hence never push, hence never
+    # fire a `synchronize` event that would re-trigger itself. And the
+    # @claude agent's own commits are pushed with GITHUB_TOKEN, which by
+    # design does not fire `synchronize` at all (claude.yml dispatches us
+    # explicitly via workflow_dispatch instead), so this clause does not
+    # double-review those.
+    #
     # The `concurrency.cancel-in-progress` expression above mirrors this
     # condition — keep the two in sync so a run that skips here never
     # cancels an in-progress peer on its way out.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]'))
+      (github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]')) ||
+      github.actor == 'claude' ||
+      github.actor == 'claude[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,6 +69,17 @@ jobs:
     # rule above was silently skipping them. The two clauses added below
     # opt those pushes back in.
     #
+    # Of the two clauses, `github.actor == 'claude[bot]'` is the
+    # load-bearing one: App-mediated pushes present as a Bot actor
+    # ending in `[bot]`, which the middle clause rejects, so without it
+    # those pushes would still be skipped. `github.actor == 'claude'`
+    # is deliberate belt-and-suspenders, NOT the thing that enables
+    # review of Claude pushes: the `claude` user (id 81847) is a regular
+    # User account, so its pushes already satisfy the middle clause
+    # (`sender.type != 'Bot' && !endsWith(actor, '[bot]')`) and are
+    # admitted without this clause. It is kept only to stay correct if
+    # that account is ever reclassified as a Bot.
+    #
     # This is safe from the self-trigger / frozen-comment recursion that
     # originally motivated skipping bot pushes (see the concurrency
     # comment above re: PR #809). This workflow is review-ONLY: the
@@ -219,6 +230,12 @@ jobs:
           # wins even though tag mode adds them. `git commit:*` is the
           # load-bearing entry (no commit -> nothing to push); the rest are
           # belt-and-suspenders in case the action's mechanics change.
+          # This disallow is ALSO load-bearing for review-loop prevention:
+          # the job `if:` Claude-bot clause (actor `claude[bot]`) above
+          # only stays recursion-safe because this reviewer cannot commit
+          # or push, so it can never fire a self-triggering `synchronize`.
+          # If you loosen this list, revisit that `if:` clause — the two
+          # are coupled.
           #
           # --append-system-prompt makes the reviewer review-ONLY at the
           # instruction level, not just the tool level. Disallowing the git


### PR DESCRIPTION
## What

Make the **Claude Code Review** workflow (`.github/workflows/claude-code-review.yml`) run on Claude-bot commits, which it was silently skipping.

## Why

The job `if:` (and the mirrored `concurrency.cancel-in-progress` expression) skipped *every* bot-actor push via the generic `endsWith(github.actor, '[bot]')` / `github.event.sender.type == 'Bot'` rule. That rule was added to stop other bots' pushes from triggering reviews, but it also excluded **Claude's own commits** — which are exactly the AI-authored diffs we most want a second pass over.

Inspecting recent Claude-authored commits in this repo, they are committed under:

- the **`claude`** user account (login `claude`, id `81847`, `noreply@anthropic.com`) — used by Claude Code on the web and the `@claude` agent, and
- **`claude[bot]`** when a push goes through the Claude GitHub App.

Both forms were being filtered out, so a Claude push to a PR left it stuck on whatever verdict existed before.

## Change

Add two clauses to both the job `if:` and the `concurrency.cancel-in-progress` expression (kept identical, per the existing in-sync invariant):

```
|| github.actor == 'claude' || github.actor == 'claude[bot]'
```

## Why this is recursion-safe

The original bot filter existed partly to avoid the self-trigger / frozen-comment loop documented in the concurrency comment (PR #809). Letting Claude-bot pushes through does **not** reintroduce it:

- This workflow is **review-only** — the review step's `--disallowedTools "Bash(git commit:*)" …` list means the reviewer can never commit, hence never push, hence can never fire a `synchronize` event that re-triggers itself.
- The `@claude` agent's own commits are pushed with `GITHUB_TOKEN`, which by design does **not** fire `synchronize` (`claude.yml` dispatches this workflow explicitly via `workflow_dispatch` instead), so those are not double-reviewed.

The load-bearing comments in both spots were updated to explain the exception and the safety argument.

## Verification

- `python3 -c "import yaml; ..."` parses the workflow and confirms the `if:` and `cancel-in-progress` expressions are byte-identical (the comments require them to stay in sync).

Per CLAUDE.md, this is a `.github`/CI/infra-only change kept in its own dedicated PR (no book content touched).

## Known CI note — `claude-review` check fails on this PR (expected)

The `claude-review` check fails here with:

> `App token exchange failed: 401 Unauthorized - Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch. ... this is normal and you should ignore this error.`

This is **inherent to editing `claude-code-review.yml` itself**, not a defect in this change. `anthropics/claude-code-action`'s OIDC app-token exchange requires the workflow file on the PR branch to be byte-identical to the one on the default branch (a guard against a PR modifying the workflow to exfiltrate the app token). Any PR that touches this workflow trips it. It clears automatically once this merges to `main` (then branch == default). The fix cannot be applied on the PR without reverting the change.

https://claude.ai/code/session_01ER1dFrUPTjaHeL3n7Yy7qG