### PR TITLE
CLAUDE.md: require URLs when referencing PRs/issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,12 @@ You are responsible for fixing failures caused by your changes only.
 Do not fix pre-existing lint/spell errors in code you didn't modify.
 If a failure is not caused by your changes, document it in the PR description.
 
+## Reporting
+
+When summarizing PRs, issues, workflow runs, or jobs, always include the
+GitHub URL alongside the reference (e.g.,
+[#897](https://github.com/d-morrison/rme/pull/897), not just "#897").
+
 ## External Resources Available in This Session
 
 - `$EPI202_TOKEN` — fine-grained PAT with read access to


### PR DESCRIPTION
## Summary

Adds a standing rule to CLAUDE.md: always include GitHub URLs when referencing PRs, issues, workflow runs, or jobs in status reports and summaries.

## Why

Caught in [this session](https://claude.ai/code/) — when summarizing PR status, I referenced `#897`/`#842`/etc. without URLs, making the user click through manually. The rule makes link-providing the default.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PtDgktdMme5SZtze1EGx9U)_