### PR TITLE
CLAUDE.md: merge main on branch pickup, not just before push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ Before committing any `.qmd`, `.R`, or config file change:
 
 ### Pull Requests
 - Remove existing review requests immediately when starting work on a PR
-- Always merge `main` into the feature branch when starting or resuming work on it — and again before pushing — not just before requesting review
+- Always merge `main` into the feature branch when starting or resuming work on it
+- Merge `main` again before pushing — not just before requesting review
 - Verify all changed hyperlinks before requesting review
 - If any `_subfiles/` were edited, add the "clear freezer" label
 - Workflow / `.github/` / CI / infra changes go in their own dedicated PRs — never mix them with book-content PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Before committing any `.qmd`, `.R`, or config file change:
 
 ### Pull Requests
 - Remove existing review requests immediately when starting work on a PR
-- Always merge `main` into the feature branch before pushing — not just before requesting review
+- Always merge `main` into the feature branch when picking it up — and again before pushing — not just before requesting review
 - Verify all changed hyperlinks before requesting review
 - If any `_subfiles/` were edited, add the "clear freezer" label
 - Workflow / `.github/` / CI / infra changes go in their own dedicated PRs — never mix them with book-content PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Before committing any `.qmd`, `.R`, or config file change:
 
 ### Pull Requests
 - Remove existing review requests immediately when starting work on a PR
-- Always merge `main` into the feature branch when picking it up — and again before pushing — not just before requesting review
+- Always merge `main` into the feature branch when starting or resuming work on it — and again before pushing — not just before requesting review
 - Verify all changed hyperlinks before requesting review
 - If any `_subfiles/` were edited, add the "clear freezer" label
 - Workflow / `.github/` / CI / infra changes go in their own dedicated PRs — never mix them with book-content PRs


### PR DESCRIPTION
## Summary

Strengthens the "merge main" rule in CLAUDE.md to require it at **branch pickup**, not just before pushing. Catches stale-base issues at the start of work, when they're cheapest to resolve.

Companion to [#897](https://github.com/d-morrison/rme/pull/897) (merge-before-push) and [#901](https://github.com/d-morrison/rme/pull/901) (URL inclusion).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PtDgktdMme5SZtze1EGx9U)_