### PR TITLE
fix: split preview workflow so fork PRs can deploy to gh-pages

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Comment with preview link
         uses: marocchino/sticky-pull-request-comment@v3
-        if: steps.meta.outputs.action == 'deploy' && steps.preview.outputs.deployment-action == 'deploy'
+        if: steps.meta.outputs.action == 'deploy' && steps.preview.outputs.deployment-action != 'none'
         continue-on-error: true
         with:
           header: pr-preview

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -53,15 +53,6 @@ jobs:
           comment: false
           action: remove
 
-      - name: Delete old preview comment
-        uses: marocchino/sticky-pull-request-comment@v3
-        if: steps.meta.outputs.action == 'deploy' && steps.preview.outputs.deployment-action == 'deploy'
-        continue-on-error: true
-        with:
-          header: pr-preview
-          number: ${{ steps.meta.outputs.pr-number }}
-          delete: true
-
       - name: Comment with preview link
         uses: marocchino/sticky-pull-request-comment@v3
         if: steps.meta.outputs.action == 'deploy' && steps.preview.outputs.deployment-action == 'deploy'

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -13,7 +13,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Cheap gate: verify the build job actually ran (vs. being skipped due to
+  # an unrecognized label). When all jobs in a workflow are skipped GitHub
+  # still reports conclusion == 'success', which would otherwise cause the
+  # deploy job to fire and fail on artifact download.
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      has-artifact: ${{ steps.check.outputs.found }}
+    steps:
+      - name: Check artifact exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name == "pr-preview-site")] | length')
+          echo "found=$([ "$count" -gt 0 ] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+
   deploy:
+    needs: gate
+    if: needs.gate.outputs.has-artifact == 'true'
     runs-on: ubuntu-latest
     # This job runs in the base-repo context (not the fork), so the
     # GITHUB_TOKEN has write access to push to gh-pages and comment on PRs.
@@ -21,7 +45,6 @@ jobs:
       contents: write
       pull-requests: write
       actions: read  # needed to download artifacts from the triggering run
-    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Check out repository

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -5,6 +5,13 @@ on:
     workflows: ["Quarto Preview Build"]
     types: [completed]
 
+# Serialize deploys for the same PR branch so two back-to-back build
+# completions don't race on gh-pages. cancel-in-progress: false queues
+# rather than kills — a mid-push cancel could corrupt gh-pages.
+concurrency:
+  group: preview-deploy-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -70,7 +77,7 @@ jobs:
 
       - name: Remove preview comment
         uses: marocchino/sticky-pull-request-comment@v3
-        if: steps.meta.outputs.action == 'remove'
+        if: steps.meta.outputs.action == 'remove' && steps.preview-remove.outputs.deployment-action == 'remove'
         continue-on-error: true
         with:
           header: pr-preview

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,92 @@
+name: Quarto Preview Deploy
+
+on:
+  workflow_run:
+    workflows: ["Quarto Preview Build"]
+    types: [completed]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # This job runs in the base-repo context (not the fork), so the
+    # GITHUB_TOKEN has write access to push to gh-pages and comment on PRs.
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read  # needed to download artifacts from the triggering run
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-preview-site
+          path: _preview_download/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          echo "pr-number=$(cat _preview_download/meta/pr-number.txt)" >> "$GITHUB_OUTPUT"
+          echo "action=$(cat _preview_download/meta/action.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy PR Preview
+        if: steps.meta.outputs.action == 'deploy'
+        uses: rossjrw/pr-preview-action@v1
+        id: preview
+        with:
+          source-dir: _preview_download/site/
+          pr-number: ${{ steps.meta.outputs.pr-number }}
+          comment: false
+          action: deploy
+
+      - name: Remove PR Preview
+        if: steps.meta.outputs.action == 'remove'
+        uses: rossjrw/pr-preview-action@v1
+        id: preview-remove
+        with:
+          pr-number: ${{ steps.meta.outputs.pr-number }}
+          comment: false
+          action: remove
+
+      - name: Delete old preview comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        if: steps.meta.outputs.action == 'deploy' && steps.preview.outputs.deployment-action == 'deploy'
+        continue-on-error: true
+        with:
+          header: pr-preview
+          number: ${{ steps.meta.outputs.pr-number }}
+          delete: true
+
+      - name: Comment with preview link
+        uses: marocchino/sticky-pull-request-comment@v3
+        if: steps.meta.outputs.action == 'deploy' && steps.preview.outputs.deployment-action == 'deploy'
+        continue-on-error: true
+        with:
+          header: pr-preview
+          number: ${{ steps.meta.outputs.pr-number }}
+          recreate: true
+          message: |
+            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview.outputs.action-version }}
+            :---:
+            :rocket: **Preview available at:** ${{ steps.preview.outputs.preview-url }}
+
+            <sub>Built to branch [`gh-pages`](${{ github.server_url }}/${{ github.repository }}/tree/gh-pages) at ${{ steps.preview.outputs.action-start-time }}.</sub>
+
+      - name: Remove preview comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        if: steps.meta.outputs.action == 'remove'
+        continue-on-error: true
+        with:
+          header: pr-preview
+          number: ${{ steps.meta.outputs.pr-number }}
+          message: |
+            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview-remove.outputs.action-version }}
+            :---:
+            Preview removed because the pull request was closed.
+
+            <sub>${{ steps.preview-remove.outputs.action-start-time }}</sub>

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -157,7 +157,9 @@ jobs:
 
       - name: Stage site for upload
         if: github.event.action != 'closed'
-        run: cp -r _site/. _preview_upload/site/
+        run: |
+          mkdir -p _preview_upload/site/
+          cp -r _site/. _preview_upload/site/
 
       - name: Upload preview artifact (deploy)
         if: github.event.action != 'closed'
@@ -172,5 +174,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pr-preview-site
-          path: _preview_upload/meta/
+          path: _preview_upload/
           retention-days: 1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -142,9 +142,9 @@ jobs:
         if: github.event.action != 'closed'
         shell: bash
         run: |
-          echo "contents of _site:\n"
+          echo "contents of _site:"
           ls _site/
-          echo "contents of .:\n"
+          echo "contents of .:"
           ls .
 
       - name: Save Quarto freeze

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,4 @@
-name: Quarto Preview
+name: Quarto Preview Build
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ on:
       - '_extensions/**'
       - '_quarto*.yml'
       - '.github/workflows/preview.yml'
-      - '.github/workflows/publish.yml'
+      - '.github/workflows/preview-deploy.yml'
       - '*.qmd'
       - 'chapters/**/*.qmd'
       - '_subfiles/**'
@@ -32,19 +32,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-deploy:
-    if: github.event_name != 'pull_request' || github.event.action != 'labeled' || contains(fromJSON('["clear freezer", "preview:pdf", "preview:docx", "preview:revealjs"]'), github.event.label.name)
+  build:
+    # Run for all events except unrecognised labels.
+    if: github.event.action != 'labeled' || contains(fromJSON('["clear freezer", "preview:pdf", "preview:docx", "preview:revealjs"]'), github.event.label.name)
     runs-on: ubuntu-latest
+    # Read-only: this job runs in the fork's restricted context and must
+    # never write to the base repo. All writes are handled by preview-deploy.yml
+    # which runs in the base-repo context via workflow_run.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+
     steps:
+      - name: Save PR metadata
+        run: |
+          mkdir -p _preview_upload/meta
+          echo "${{ github.event.pull_request.number }}" > _preview_upload/meta/pr-number.txt
+          echo "${{ github.event.action == 'closed' && 'remove' || 'deploy' }}" > _preview_upload/meta/action.txt
+
       - name: Check out repository
+        if: github.event.action != 'closed'
         uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Set up Quarto
+        if: github.event.action != 'closed'
         uses: quarto-dev/quarto-actions/setup@v2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,11 +64,13 @@ jobs:
           tinytex: false
 
       - uses: r-lib/actions/setup-r@v2
+        if: github.event.action != 'closed'
         with:
           r-version: '4.6.0'
           use-public-rspm: true
 
       - name: Install system dependencies
+        if: github.event.action != 'closed'
         run: |
           sudo apt-get update
           # `libglpk-dev` is required for the igraph/ggdag/ggraph dependency stack.
@@ -67,20 +81,21 @@ jobs:
           # `libx11-dev`, and `pandoc`),
           # so the full list here is intentionally broader than publish/lint.
           sudo apt-get install -y jags libcurl4-openssl-dev libpng-dev libfontconfig1-dev libjpeg-dev libglpk-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libtiff5-dev libwebp-dev libnode109 cmake libgit2-dev libnode-dev libx11-dev pandoc
-          
 
       - name: Setup Chrome
+        if: github.event.action != 'closed'
         uses: browser-actions/setup-chrome@v1
-  
+
       - uses: r-lib/actions/setup-renv@v2
+        if: github.event.action != 'closed'
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         with:
           bypass-cache: never
 
       - name: Install local package
-        run: |
-          R CMD INSTALL .
+        if: github.event.action != 'closed'
+        run: R CMD INSTALL .
 
       - name: Set up TinyTeX
         if: github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'preview:pdf')
@@ -121,10 +136,10 @@ jobs:
         run: quarto render --profile website --to revealjs --no-clean
 
       - name: Render html (website profile)
-        if: github.event.action != 'closed' # skip the build if the PR has been closed
+        if: github.event.action != 'closed'
         run: quarto render --profile website --to html --no-clean
 
-      - name: list files
+      - name: List files
         if: github.event.action != 'closed'
         shell: bash
         run: |
@@ -139,46 +154,23 @@ jobs:
         with:
           path: _freeze
           key: quarto-freezer-${{ runner.os }}-${{ hashFiles('renv.lock') }}-${{ github.event.pull_request.head.sha }}-${{ github.run_attempt }}
-      
-      - name: Deploy PR Preview
-        uses: rossjrw/pr-preview-action@v1
-        id: preview
+
+      - name: Stage site for upload
+        if: github.event.action != 'closed'
+        run: cp -r _site/. _preview_upload/site/
+
+      - name: Upload preview artifact (deploy)
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@v4
         with:
-          source-dir: _site/
-          comment: false
-          action: ${{ github.event.action != 'closed' && 'deploy' || 'remove' }}
-      
-      - name: Delete old preview comment
-        uses: marocchino/sticky-pull-request-comment@v3
-        if: steps.preview.outputs.deployment-action == 'deploy'
-        continue-on-error: true
+          name: pr-preview-site
+          path: _preview_upload/
+          retention-days: 1
+
+      - name: Upload preview artifact (remove)
+        if: github.event.action == 'closed'
+        uses: actions/upload-artifact@v4
         with:
-          header: pr-preview
-          delete: true
-      
-      - name: Comment with preview link
-        uses: marocchino/sticky-pull-request-comment@v3
-        if: steps.preview.outputs.deployment-action == 'deploy'
-        continue-on-error: true
-        with:
-          header: pr-preview
-          recreate: true
-          message: |
-            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview.outputs.action-version }}
-            :---:
-            :rocket: **Preview available at:** ${{ steps.preview.outputs.preview-url }}
-            
-            <sub>Built to branch [`gh-pages`](${{ github.server_url }}/${{ github.repository }}/tree/gh-pages) at ${{ steps.preview.outputs.action-start-time }}.</sub>
-      
-      - name: Remove preview comment
-        uses: marocchino/sticky-pull-request-comment@v3
-        if: steps.preview.outputs.deployment-action == 'remove'
-        continue-on-error: true
-        with:
-          header: pr-preview
-          message: |
-            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview.outputs.action-version }}
-            :---:
-            Preview removed because the pull request was closed.
-            
-            <sub>${{ steps.preview.outputs.action-start-time }}</sub>
+          name: pr-preview-site
+          path: _preview_upload/meta/
+          retention-days: 1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,6 @@ on:
       - '_extensions/**'
       - '_quarto*.yml'
       - '.github/workflows/preview.yml'
-      - '.github/workflows/preview-deploy.yml'
       - '*.qmd'
       - 'chapters/**/*.qmd'
       - '_subfiles/**'


### PR DESCRIPTION
## Summary

- The old `preview.yml` ran entirely under `pull_request`, giving fork PRs a read-only `GITHUB_TOKEN` that can't push to `gh-pages` (403 error seen in [PR #846](https://github.com/d-morrison/rme/pull/846)).
- Splits into two workflows using the standard `workflow_run` pattern:
  - **`preview.yml`** (`name: Quarto Preview Build`) — triggers on `pull_request`, `contents: read` only. Builds the site and uploads a `pr-preview-site` artifact with the rendered site + PR metadata (`meta/pr-number.txt`, `meta/action.txt`).
  - **`preview-deploy.yml`** (`name: Quarto Preview Deploy`) — triggers via `workflow_run` on build completion. Runs in the base-repo context with `contents: write`, downloads the artifact, pushes to `gh-pages`, and posts PR comments.
- PR number is embedded in the artifact because `github.event.workflow_run.pull_requests` is empty for fork PRs (GitHub strips it for security).

## Test plan

- [ ] Open a PR from a fork and confirm `Quarto Preview Build` passes and `Quarto Preview Deploy` successfully pushes the preview and posts the preview URL comment
- [ ] Close a fork PR and confirm the deploy workflow removes the preview and updates the comment
- [ ] Open a PR from a non-fork branch and confirm both workflows behave identically to before

https://claude.ai/code/session_01CjeVhx6eX7p8W5kLdmMNht

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjeVhx6eX7p8W5kLdmMNht)_