### PR TITLE
Fix missing parentheses in causal-inference probability equations

### DIFF
--- a/_subfiles/causal-inference/_sec-pred-sel-dag.qmd
+++ b/_subfiles/causal-inference/_sec-pred-sel-dag.qmd
@@ -86,7 +86,7 @@ with respect to the ordered pair $(A, Y)$ in a DAG if:
 
 If $\vec{L}$ satisfies the backdoor criterion,
 then adjusting for $\vec{L}$ identifies the causal effect of $A$ on $Y$:
-$$\E{Y(a)} = \sum_{\vec{l}} \E{Y \mid A = a, \vec{L} = \vec{l}} \P{\vec{L} = \vec{l}}$$
+$$\E{Y(a)} = \sum_{\vec{l}} \E{Y \mid A = a, \vec{L} = \vec{l}} \P\paren{\vec{L} = \vec{l}}$$
 
 :::
 

--- a/_subfiles/causal-inference/_sec-pred-sel-dag.qmd
+++ b/_subfiles/causal-inference/_sec-pred-sel-dag.qmd
@@ -86,7 +86,7 @@ with respect to the ordered pair $(A, Y)$ in a DAG if:
 
 If $\vec{L}$ satisfies the backdoor criterion,
 then adjusting for $\vec{L}$ identifies the causal effect of $A$ on $Y$:
-$$\E{Y(a)} = \sum_{\vec{l}} \E{Y \mid A = a, \vec{L} = \vec{l}} \P\paren{\vec{L} = \vec{l}}$$
+$$\E{Y(a)} = \sum_{\vec{l}} \E{Y \mid A = a, \vec{L} = \vec{l}} \Pf{\vec{L} = \vec{l}}$$
 
 :::
 

--- a/_subfiles/causal-inference/_sec_assumptions.qmd
+++ b/_subfiles/causal-inference/_sec_assumptions.qmd
@@ -54,7 +54,7 @@ The **positivity** assumption states that
 every individual has a positive probability of receiving
 each treatment level,
 conditional on their covariate values:
-$$0 < \P\paren{A = 1 \mid \vec{L} = \vec{l}} < 1
+$$0 < \Pf{A = 1 \mid \vec{L} = \vec{l}} < 1
 \quad \text{for all } \vec{l} \text{ in the support of } \vec{L}$$
 
 Without positivity,

--- a/_subfiles/causal-inference/_sec_assumptions.qmd
+++ b/_subfiles/causal-inference/_sec_assumptions.qmd
@@ -54,7 +54,7 @@ The **positivity** assumption states that
 every individual has a positive probability of receiving
 each treatment level,
 conditional on their covariate values:
-$$0 < \P{A = 1 \mid \vec{L} = \vec{l}} < 1
+$$0 < \P\paren{A = 1 \mid \vec{L} = \vec{l}} < 1
 \quad \text{for all } \vec{l} \text{ in the support of } \vec{L}$$
 
 Without positivity,

--- a/_subfiles/causal-inference/_sec_propensity_scores.qmd
+++ b/_subfiles/causal-inference/_sec_propensity_scores.qmd
@@ -11,7 +11,7 @@ the propensity score.
 
 The **propensity score** is the conditional probability of treatment
 given the observed covariates:
-$$e(\vec{L}) = \P{A = 1 \mid \vec{L}}$$
+$$e(\vec{L}) = \P\paren{A = 1 \mid \vec{L}}$$
 
 @rosenbaum1983central showed that
 if $A \perp\!\!\!\perp (Y(0), Y(1)) \mid \vec{L}$

--- a/_subfiles/causal-inference/_sec_propensity_scores.qmd
+++ b/_subfiles/causal-inference/_sec_propensity_scores.qmd
@@ -11,7 +11,7 @@ the propensity score.
 
 The **propensity score** is the conditional probability of treatment
 given the observed covariates:
-$$e(\vec{L}) = \P\paren{A = 1 \mid \vec{L}}$$
+$$e(\vec{L}) = \Pf{A = 1 \mid \vec{L}}$$
 
 @rosenbaum1983central showed that
 if $A \perp\!\!\!\perp (Y(0), Y(1)) \mid \vec{L}$


### PR DESCRIPTION
## Problem

In the **Causal Inference** chapter, the positivity-assumption equation — linked as [`#eq-anchor-9`](https://d-morrison.github.io/rme/chapters/causal-inference.html#eq-anchor-9) — renders without parentheses around the probability event:

> P A = 1 ∣ L = l

instead of the intended **P(A = 1 ∣ L = l)**.

### Root cause

The `\P` macro is defined as `\def\P{\distop{P}}` → `\operatorname{P}`, which takes **no argument**. So `\P{A = 1 \mid \vec{L} = \vec{l}}` treats `{…}` as an invisible math group, producing `\operatorname{P}` immediately followed by the event with no delimiters.

## Fix

Use the existing function-form macro `\Pf{…}` (`\providecommand{\Pf}[1]{\P\paren{#1}}`, `latex-macros/macros.qmd:322`), which wraps the event in auto-sized parentheses via `\paren`. This matches the house convention for function-form macros (`\Sf`, `\Qf`, `\Prf`, …).

Fixed in **three** equations, all of which render in the chapter:

- `_sec_assumptions.qmd` — positivity assumption (`eq-anchor-9`)
- `_sec_propensity_scores.qmd` — propensity-score definition `e(L) = P(A = 1 ∣ L)`
- `_sec-pred-sel-dag.qmd` — G-computation identification formula `… P(L = l)`

Rendered LaTeX after the fix:

```
0 < \operatorname{P}\left(A = 1 \mid \tilde{L} = \tilde{l}\right) < 1 \quad \text{for all } ...
e(\tilde{L}) = \operatorname{P}\left(A = 1 \mid \tilde{L}\right)
\operatorname{E}\left[Y(a)\right] = \sum_{\tilde{l}} \operatorname{E}\left[Y \mid A = a, \tilde{L} = \tilde{l}\right] \operatorname{P}\left(\tilde{L} = \tilde{l}\right)
```

## Notes

- **Correction to an earlier draft of this description:** `_sec-pred-sel-dag.qmd` is **not** an orphan — it is included via `chapters/causal-inference.qmd:75` → `_sec_observational.qmd:36` → `_sec-pred-sel-dag.qmd`. The G-computation equation was therefore a **live** rendering bug, not latent dead code. (My initial grep missed the include because `chapters/_subfiles` is a symlink to `../_subfiles` and ripgrep didn't follow it.)
- All three equations were verified by rendering `chapters/causal-inference.qmd --to html` and inspecting the emitted MathJax — every `P(…)` now has parentheses.
- `lintr` / `spelling` could not be run locally — the `renv` library is not restored in this container. The change is a single LaTeX macro per equation inside display math (no R code, no new prose words), so neither check can regress from it; CI's `lint-changed-files` and `Spellcheck` jobs confirm.

## Commits

- `0b99a3b` — fix positivity + propensity equations
- `3ea37a9` — fix the G-computation equation in `_sec-pred-sel-dag.qmd`
- `73c5ff8` — switch all three to the canonical `\Pf{…}` function-form macro
