### PR TITLE
CLAUDE.md: add ~100-line source file length convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Before committing any `.qmd`, `.R`, or config file change:
 ### File Structure
 - Subfiles (`_subfiles/`) must NOT begin with a section heading — place headings in the parent `.qmd`
 - Link to `.qmd` source files, not rendered `.html` files
+- Aim to keep source files under ~100 lines; split longer files into named subfiles
 - `_extensions/` is vendored third-party code — do not review or modify it
 
 ### Quarto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Before committing any `.qmd`, `.R`, or config file change:
 ### File Structure
 - Subfiles (`_subfiles/`) must NOT begin with a section heading — place headings in the parent `.qmd`
 - Link to `.qmd` source files, not rendered `.html` files
-- Aim to keep source files under ~100 lines; split longer files into named subfiles
+- Aim to keep `.qmd` source files under ~100 lines; split longer files into named subfiles in `_subfiles/`
 - `_extensions/` is vendored third-party code — do not review or modify it
 
 ### Quarto


### PR DESCRIPTION
## Summary

Adds a single **File Structure** guideline to `CLAUDE.md`:

> - Aim to keep source files under ~100 lines; split longer files into named subfiles

## Why

A review on [#843](https://github.com/d-morrison/rme/pull/843) requested (1) decomposing the 462-line `_sec_double_integrals.qmd` into focused subfiles, and (2) recording the ~100-line size convention in `CLAUDE.md`.

The decomposition is handled in #843. This convention change is kept in its own dedicated PR per the `CLAUDE.md` rule that *"Workflow / .github / CI / infra changes go in their own dedicated PRs — never mix them with book-content PRs."*

## Scope

One-line documentation change to `CLAUDE.md`; no `.qmd`/`.R`/content touched, so no render/lint/spell run is required.

https://claude.ai/code/session_01NQSLJmjMN22RpwpgJ6Lw6u

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQSLJmjMN22RpwpgJ6Lw6u)_