### PR TITLE
claude.yml: grant actions:write so @claude can dispatch code review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,7 +57,17 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      # `write` (not `read`) is required: besides letting Claude read CI
+      # results on PRs, the post-Claude steps below call `gh workflow run
+      # claude-code-review.yml` (the workflow_dispatch REST endpoint
+      # `POST /actions/workflows/{id}/dispatches`), which GITHUB_TOKEN can
+      # only reach with `actions: write`. With `actions: read` every
+      # dispatch 403s ("Resource not accessible by integration") and is
+      # swallowed by the `|| echo "::warning::"` fallback, so the
+      # code-review never auto-runs (observed on PR #900, run
+      # 27598978484: the @claude-review dispatch 403'd silently). `write`
+      # is a superset of `read`, so CI reads still work.
+      actions: write
     # Expose the ucdavis/epi202 and ucdavis/epi204 fine-grained PATs to
     # every step in this job, including the Claude action's subprocess.
     # See .github/copilot-instructions.md ("Accessing the private
@@ -847,11 +857,13 @@ jobs:
             gh api -X POST \
               "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
               -f "reviewers[]=d-morrison" || true
-            # Fire claude-code-review.yml via workflow_dispatch. The default
-            # GITHUB_TOKEN is permitted to trigger workflow_dispatch (unlike
-            # push, which is blocked to avoid recursion), and the review
-            # workflow's own `concurrency` group will cancel any in-flight
-            # review for this PR so the freshest diff wins.
+            # Fire claude-code-review.yml via workflow_dispatch. GITHUB_TOKEN
+            # may trigger workflow_dispatch (unlike push, which is blocked to
+            # avoid recursion) — but ONLY with `actions: write` in this job's
+            # `permissions:` (see the note there); with `actions: read` the
+            # dispatch 403s silently. The review workflow's own `concurrency`
+            # group then cancels any in-flight review for this PR so the
+            # freshest diff wins.
             gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" || \
               echo "::warning::Could not dispatch claude-code-review.yml; review will not auto-run."
           else


### PR DESCRIPTION
## What

Grant the `claude.yml` job `actions: write` (was `actions: read`) so the post-Claude steps can actually dispatch the dedicated code-review workflow.

## Root cause

`claude.yml` fires the reviewer via `gh workflow run claude-code-review.yml` (the `workflow_dispatch` REST endpoint `POST /actions/workflows/{id}/dispatches`) in three steps. That endpoint requires **`actions: write`** for `GITHUB_TOKEN`, but the job only granted `actions: read`. So every dispatch returned:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
  (.../actions/workflows/273583888/dispatches)
```

…and the error was swallowed by the `|| echo "::warning::…"` fallback on each call. Net effect: **`@claude review` (and the post-commit auto-dispatch) silently never triggered a review.**

### Evidence

- Directly observed in `claude.yml` run [27598978484](https://github.com/d-morrison/rme/actions/runs/27598978484/job/81595311478), step *"Dispatch claude-code-review.yml on @claude review comment"*: the 403 above, immediately followed by the swallowed warning.
- On PR #900, two `@claude review` requests produced only the "👀 Picked up…" ack and **no review** — and `get_reviews`/`get_comments` show no review content was ever posted there.
- No `workflow_dispatch` run of `claude-code-review.yml` has fired from `claude.yml`. (The handful of `workflow_dispatch` runs in the history are from **May** and predate the affected PRs — most likely manual dispatches.)
- `git blame` puts `actions: read` on this job since 2026-05-08, so this has been broken since at least then.

## Change

- `actions: read` → `actions: write` in the `claude` job's `permissions:` (one line; `write` is a superset of `read`, so Claude's CI-result reads are unaffected).
- Corrected the inline comment that claimed `GITHUB_TOKEN` "is permitted to trigger workflow_dispatch" without noting the `actions: write` requirement, and added a note at the `permissions:` block so a future edit doesn't silently re-break it.

## Verification

- `python3 -c "import yaml; ..."` parses `claude.yml` and confirms `permissions.actions == 'write'`.
- The fix can only be fully confirmed once merged (a real `@claude review` should then produce a dispatched `claude-code-review.yml` run instead of a swallowed 403).

## Context / related

This is the real fix for the gap that PR #900 was trying (ineffectively) to address. Investigation on #900 showed its actor-filter approach is a no-op — Claude's PR pushes arrive as actor `d-morrison` (already reviewed) and `claude[bot]` only ever fires `issue_comment`, never `pull_request` — so the actual reason Claude-authored commits weren't getting reviewed is this broken dispatch, not the `if:` filter. #900 is being closed in favor of this PR.

Per CLAUDE.md, this is a `.github`/CI-only change kept in its own dedicated PR.

https://claude.ai/code/session_01ER1dFrUPTjaHeL3n7Yy7qG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ER1dFrUPTjaHeL3n7Yy7qG)_