### PR TITLE
Fix PR-preview deploys: write metadata after checkout (survives git clean)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -60,9 +60,15 @@ jobs:
 
       - name: Read PR metadata
         id: meta
+        # Fail loudly if the metadata is missing. A bare `$(cat missing)`
+        # inside `echo` yields empty output and exit 0, so the step would
+        # "pass" with empty pr-number/action and the deploy would silently
+        # skip (the regression this workflow pair just recovered from).
         run: |
-          echo "pr-number=$(cat _preview_download/meta/pr-number.txt)" >> "$GITHUB_OUTPUT"
-          echo "action=$(cat _preview_download/meta/action.txt)" >> "$GITHUB_OUTPUT"
+          pr_number=$(cat _preview_download/meta/pr-number.txt) || { echo "::error::Missing pr-number.txt in preview artifact"; exit 1; }
+          action=$(cat _preview_download/meta/action.txt) || { echo "::error::Missing action.txt in preview artifact"; exit 1; }
+          echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "action=$action" >> "$GITHUB_OUTPUT"
 
       - name: Deploy PR Preview
         if: steps.meta.outputs.action == 'deploy'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,17 +42,27 @@ jobs:
       contents: read
 
     steps:
-      - name: Save PR metadata
-        run: |
-          mkdir -p _preview_upload/meta
-          echo "${{ github.event.pull_request.number }}" > _preview_upload/meta/pr-number.txt
-          echo "${{ github.event.action == 'closed' && 'remove' || 'deploy' }}" > _preview_upload/meta/action.txt
-
       - name: Check out repository
         if: github.event.action != 'closed'
         uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      # IMPORTANT: write the metadata AFTER checkout. actions/checkout runs
+      # `git clean -ffdx` (clean: true is the default), which deletes any
+      # untracked files already in the workspace — including a
+      # `_preview_upload/` directory created beforehand. With the metadata
+      # written before checkout, `_preview_upload/meta/` was wiped and never
+      # reached the artifact, so preview-deploy.yml read an empty pr-number,
+      # the deploy step's `action == 'deploy'` guard was false, and every
+      # deploy-path preview was silently skipped (the job still passed).
+      # For the 'closed'/remove event the checkout step is skipped, but this
+      # step is unguarded and still runs, so the remove path is unaffected.
+      - name: Save PR metadata
+        run: |
+          mkdir -p _preview_upload/meta
+          echo "${{ github.event.pull_request.number }}" > _preview_upload/meta/pr-number.txt
+          echo "${{ github.event.action == 'closed' && 'remove' || 'deploy' }}" > _preview_upload/meta/action.txt
 
       - name: Set up Quarto
         if: github.event.action != 'closed'


### PR DESCRIPTION
## Problem

PR-preview deploys silently stopped publishing: preview **builds** pass and the `pr-preview-site` artifact uploads (~27 MB), but the preview never appears on `gh-pages` and **all checks stay green**. Affects every deploy-path (non-closed) PR — e.g. [#912](https://github.com/d-morrison/rme/pull/912) builds fine but `https://d-morrison.github.io/rme/pr-preview/pr-912/` 404s, and `pr-912/` is absent from `gh-pages`. The `pr-preview/pr-NNN` dirs currently on `gh-pages` are stale (from before this regression).

## Root cause

In `preview.yml` the steps ran:

1. **Save PR metadata** → `mkdir -p _preview_upload/meta`, write `pr-number.txt` / `action.txt` — *before checkout*
2. **Check out repository** → `actions/checkout@v5` (default `clean: true`) runs `git clean -ffdx`, **deleting the untracked `_preview_upload/`** (incl. `meta/`)
3. … render …
4. **Stage site** → recreates `_preview_upload/site/` (after checkout, so it survives)
5. **Upload** `pr-preview-site` = `_preview_upload/` → contains only `site/`, **no `meta/`**

Then `preview-deploy.yml`'s "Read PR metadata" `cat`s the missing files:

```
cat: _preview_download/meta/pr-number.txt: No such file or directory
cat: _preview_download/meta/action.txt: No such file or directory
```

→ `pr-number`/`action` outputs empty → `if: steps.meta.outputs.action == 'deploy'` is false → **Deploy step skipped**, but the failed `cat` doesn't fail the step, so the job reports **success**.

### Evidence
- Deploy run for #912's build (`27786018099`) logs the two `cat: … No such file` lines, then skips the deploy step; job = success.
- Downloading the `pr-preview-site` artifact from the build directly shows a top level of **`site/` only — no `meta/`**.

## Fix

Move **Save PR metadata** to run **after** "Check out repository", so the files are created *after* `git clean` and survive into the artifact. It only needs `github.event.pull_request.number`, available regardless of checkout. The step stays unguarded, so the `closed`/remove path (which skips checkout) is unaffected. Added a comment so the load-bearing ordering isn't reverted.

## Validation

This PR's own preview build runs the fixed `preview.yml` (head-branch version), so if the deploy publishes `pr-preview/pr-<this-PR>/`, the fix is confirmed end-to-end. Note: open PRs like #912 will need `main` merged in (or a re-run) to pick up the fixed workflow for their own previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)