### PR TITLE
claude.yml: don't self-trigger on bot-authored @claude comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,11 +46,28 @@ concurrency:
 
 jobs:
   claude:
+    # Only a HUMAN @claude mention should invoke the agent. Skip events
+    # whose sender is a bot, otherwise the agent self-triggers: a comment
+    # posted by claude[bot] (the agent's own GitHub App identity) that
+    # merely *contains* `@claude` — quoting a prior `@claude ...` command,
+    # or a "posted by @claude" signature — re-fires this workflow, which
+    # posts another such comment, which re-fires it again, unbounded
+    # (observed on PR #900, 2026-06-16). The `Acknowledge @claude mention`
+    # ack below is posted via GITHUB_TOKEN (github-actions[bot]), and
+    # GITHUB_TOKEN-authored events cannot trigger workflows — but claude[bot]
+    # comments are posted with the Claude GitHub App token, which DOES fire
+    # `issue_comment`, so guarding on the token kind is not enough; we guard
+    # on the author. `github.event.sender` is the actor that raised the
+    # event (comment/review author or issue opener) for all four trigger
+    # types; this mirrors the `sender.type != 'Bot'` filter in
+    # claude-code-review.yml.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,10 +59,13 @@ jobs:
     # `issue_comment`, so guarding on the token kind is not enough; we guard
     # on the author. `github.event.sender` is the actor that raised the
     # event (comment/review author or issue opener) for all four trigger
-    # types; this mirrors the `sender.type != 'Bot'` filter in
-    # claude-code-review.yml.
+    # types; this mirrors the `sender.type != 'Bot' && !endsWith(actor,
+    # '[bot]')` double guard in claude-code-review.yml. The second clause
+    # is belt-and-suspenders: it also blocks a bot actor whose
+    # `sender.type` is somehow not reported as 'Bot' (old/misconfigured
+    # integrations), and keeps the two workflows idiomatically identical.
     if: |
-      github.event.sender.type != 'Bot' && (
+      github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]') && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
## What

Guard the **Claude Code** agent workflow (`.github/workflows/claude.yml`) so it only runs when a **human** mentions `@claude` — not when a bot-authored comment merely contains the string `@claude`.

## Why

The job `if:` triggered on *any* comment/review/issue whose body contains `@claude`, with **no guard on the author**:

```yaml
if: |
  (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
  ...
```

That let the agent **re-trigger itself**. A comment posted by `claude[bot]` (the agent's own GitHub App identity) that merely *contains* `@claude` — e.g. quoting a prior `` `@claude fix nits` `` command, or a `posted by @claude` signature — satisfies the `if:` and fires a fresh run, which posts another such comment, which fires it again: an **unbounded self-trigger loop**.

This was observed live on **#900** on 2026-06-16: a status comment containing the literal `@claude fix nits` dispatched a run; that run's `claude[bot]` comment echoed `@claude` while explaining the false-positive; that re-dispatched the workflow; and so on (~12–15 min per iteration). See runs [27646413589](https://github.com/d-morrison/rme/actions/runs/27646413589) → [27646992663](https://github.com/d-morrison/rme/actions/runs/27646992663).

### Why the existing protection didn't cover it

The inline comment on the `Acknowledge @claude mention` step notes that the ack can't self-loop. That's true — but only because the ack is posted via `GITHUB_TOKEN` (as `github-actions[bot]`), and **`GITHUB_TOKEN`-authored events cannot trigger workflows**. `claude[bot]` comments, however, are posted with the **Claude GitHub App token**, which *does* fire `issue_comment`. So the token-kind protection never applied to the agent's own App-authored comments.

## Change

Gate the job on the comment/review/issue author not being a bot:

```yaml
if: |
  github.event.sender.type != 'Bot' && !endsWith(github.actor, '[bot]') && (
    (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
    (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
    (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
    (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
  )
```

`github.event.sender` is the actor that raised the event (the comment/review author or issue opener) for all four trigger types, so a single top-level guard covers them uniformly. This **mirrors the full `sender.type != 'Bot' && !endsWith(github.actor, '[bot]')` double guard already used in `claude-code-review.yml`**, keeping the two workflows idiomatically identical. (`sender.type != 'Bot'` alone is sufficient for the observed `claude[bot]` loop; the `!endsWith(actor, '[bot]')` clause is belt-and-suspenders for a bot actor whose `sender.type` is somehow not reported as `Bot` — added in response to review feedback.)

Intended human invocations (OWNER/MEMBER typing `@claude`) are unaffected — human actor logins never end in `[bot]`. If a specific automation should ever be allowed to invoke the agent, add an explicit allow-clause (the same pattern #900 proposed for letting Claude *pushes* through the review filter).

## Verification

- `python3` parses the workflow; the `jobs.claude.if` expression has balanced parentheses (12/12), retains all four trigger conditions, and includes the `sender.type != 'Bot' && !endsWith(github.actor, '[bot]')` double guard.
- No other job exists in the file (single `claude` job), so no mirrored expression to keep in sync (`concurrency.cancel-in-progress` here is the literal `false`).
- Merged latest `main` (which added `actions: write` to this job) cleanly.

Per CLAUDE.md, this is a `.github`/CI-only change in its own dedicated PR (no book content touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGCFAvjMVUtwCpRgSFr81G