### PR TITLE
ci: auto-update the macros submodule via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keep git submodules up to date automatically.
+#
+# This repo embeds the shared `macros` repo as a git submodule (at
+# `latex-macros/`, tracking `main`). Dependabot's `gitsubmodule` updater opens a
+# PR whenever the tracked branch advances, so we no longer have to bump the
+# pointer by hand. See the ADR at d-morrison/macros
+# (docs/adr/0001-macros-submodule-versioning.md) for why we track `main` rather
+# than a pinned release tag.
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(submodule)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(submodule)"
+    # macros changes ripple through every chapter that uses them, so each bump
+    # PR needs the Quarto freeze cache cleared, so tag it to keep that in view.
+    labels:
+      - "clear freezer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,6 @@ updates:
     commit-message:
       prefix: "chore(submodule)"
     # macros changes ripple through every chapter that uses them, so each bump
-    # PR needs the Quarto freeze cache cleared, so tag it to keep that in view.
+    # PR needs the Quarto freeze cache cleared; this label keeps that visible.
     labels:
       - "clear freezer"


### PR DESCRIPTION
## Summary

Adds a Dependabot config so the **`macros` submodule is bumped automatically** instead of by hand.

This repo embeds `macros` as a submodule at `latex-macros/`, tracking `main`. Dependabot's `gitsubmodule` updater opens a PR whenever that branch advances, removing the manual `git submodule update --remote` + commit step.

## Why this (and not a sliding tag)

Follow-through on the ADR in [`d-morrison/macros`](https://github.com/d-morrison/macros/blob/main/docs/adr/0001-macros-submodule-versioning.md): a sliding tag/branch wouldn't remove the manual bump, because a submodule gitlink only advances when a consumer updates *and commits* it. Dependabot is the automation that actually closes that loop — and it tracks a branch (`main`), the only ref that `--remote`-style tracking can follow.

## Config

```yaml
package-ecosystem: "gitsubmodule"
directory: "/"
schedule: { interval: "weekly" }
```

Weekly cadence keeps PR noise low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN)_