### PR TITLE
docs(CLAUDE.md): watch PRs until merged/closed by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ Before committing any `.qmd`, `.R`, or config file change:
 - Verify all changed hyperlinks before requesting review
 - If any `_subfiles/` were edited, add the "clear freezer" label
 - Workflow / `.github/` / CI / infra changes go in their own dedicated PRs — never mix them with book-content PRs
+- After opening (or when asked to watch) a PR, subscribe to its activity and keep watching until it is merged or closed: confirm CI results, surface review comments, and catch merge conflicts; re-arm a periodic check-in and only ping when something needs the author. Stop immediately if the author asks you to back off.
 
 ## Workflow Responsibility
 


### PR DESCRIPTION
## What

Adds one convention to the **Pull Requests** section of `CLAUDE.md`:

> After opening (or when asked to watch) a PR, subscribe to its activity and keep watching until it is merged or closed: confirm CI results, surface review comments, and catch merge conflicts; re-arm a periodic check-in and only ping when something needs the author. Stop immediately if the author asks you to back off.

## Why

Requested by @d-morrison as a standing default so PRs get watched through to merge without having to ask each time. The "back off" clause keeps it from interfering when the author wants to drive a PR themselves.

## Notes

- Docs-only, single-line addition — no code, render, lint, or spell impact.
- Infra/meta change kept in its own PR per `CLAUDE.md` (not mixed with book content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbqjCwkggGX5yFzXQSafhd)_