### PR TITLE
ci: also auto-update GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Keep git submodules up to date automatically.
+# Keep git submodules and pinned GitHub Actions up to date automatically.
 #
 # This repo embeds the shared `macros` repo as a git submodule (at
 # `latex-macros/`, tracking `main`). Dependabot's `gitsubmodule` updater opens a
@@ -18,3 +18,13 @@ updates:
     # PR needs the Quarto freeze cache cleared; this label keeps that visible.
     labels:
       - "clear freezer"
+
+  # Also keep pinned GitHub Actions current. Dependabot scans .github/workflows/
+  # and opens a PR when a newer release of a pinned action is available;
+  # unversioned @HEAD / @main pins are left untouched.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(actions)"


### PR DESCRIPTION
## Summary

Follow-up to the merged Dependabot submodule PR ([#916](https://github.com/d-morrison/rme/pull/916)). Adds a second Dependabot ecosystem, `github-actions`, so pinned action versions in `.github/workflows/` (e.g. `actions/checkout`, `r-lib/actions/*`, `quarto-dev/quarto-actions/*`) get bumped automatically too.

Two reviewers suggested this on the submodule PRs; I kept it out of those to keep them scoped, and split it here as requested.

## Config

```yaml
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule: { interval: "weekly" }
    commit-message: { prefix: "chore(actions)" }
```

Weekly cadence; unversioned `@HEAD`/`@main` pins are left untouched by Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN)_