### PR TITLE
count-regression: frame quasi-Poisson as an inference method, not a distribution

### DIFF
--- a/chapters/count-regression.qmd
+++ b/chapters/count-regression.qmd
@@ -88,11 +88,12 @@ and we can combine this model with zero-inflation
 
 ## Quasipoisson
 
-Another way to handle overdispersion — rather than switching to the
-negative binomial distributional family — is the "quasipoisson" approach.
+Another way to handle overdispersion —
+rather than switching to the negative binomial distributional family —
+is the "quasipoisson" approach.
 I've never used it,
-but rather than specifying a full probability distribution and fitting by maximum likelihood,
-it is a method-of-moments-type *inference method*:
+but it is a method-of-moments-type *inference method*:
+rather than specifying a full probability distribution and fitting by maximum likelihood,
 it specifies only the mean-variance relationship $\Var{Y} = \mu\theta$,
 and estimates $\theta$ accordingly.
 

--- a/chapters/count-regression.qmd
+++ b/chapters/count-regression.qmd
@@ -88,7 +88,13 @@ and we can combine this model with zero-inflation
 
 ## Quasipoisson
 
-An alternative to the negative binomial model is the "quasipoisson" approach. I've never used it, but rather than specifying a full probability distribution and fitting by maximum likelihood, it is a method-of-moments-type approach: it specifies only the mean-variance relationship $\Var{Y} = \mu\theta$, and estimates $\theta$ accordingly. In other words, "quasipoisson" names an *inference method* (defined by a mean-variance relationship), not a model *structure* (a full distributional family) the way the negative binomial does.
+Another way to handle overdispersion — rather than switching to the
+negative binomial distributional family — is the "quasipoisson" approach.
+I've never used it,
+but rather than specifying a full probability distribution and fitting by maximum likelihood,
+it is a method-of-moments-type *inference method*:
+it specifies only the mean-variance relationship $\Var{Y} = \mu\theta$,
+and estimates $\theta$ accordingly.
 
 See `?quasipoisson` in R for more.
 

--- a/chapters/count-regression.qmd
+++ b/chapters/count-regression.qmd
@@ -88,7 +88,7 @@ and we can combine this model with zero-inflation
 
 ## Quasipoisson
 
-An alternative to Negative binomial is the "quasipoisson" distribution. I've never used it, but it seems to be a method-of-moments type approach rather than maximum likelihood. It models the variance as $\Var{Y} = \mu\theta$, and estimates $\theta$ accordingly.
+An alternative to the negative binomial model is the "quasipoisson" approach. I've never used it, but rather than specifying a full probability distribution and fitting by maximum likelihood, it is a method-of-moments-type approach: it specifies only the mean-variance relationship $\Var{Y} = \mu\theta$, and estimates $\theta$ accordingly. In other words, "quasipoisson" names an *inference method* (defined by a mean-variance relationship), not a model *structure* (a full distributional family) the way the negative binomial does.
 
 See `?quasipoisson` in R for more.
 


### PR DESCRIPTION
## What

Applies the **model structure vs. inference method** convention (CLAUDE.md → Content Writing) to `chapters/count-regression.qmd`.

The "Quasipoisson" section called quasi-Poisson a *"distribution"* and listed it as "an alternative to Negative binomial" (a genuine distributional family), while in the same sentence correctly describing it as "a method-of-moments type approach rather than maximum likelihood." That conflates the two axes: quasi-Poisson is a **quasi-likelihood / method-of-moments-type inference method** defined only by a mean–variance relationship $\Var{Y} = \mu\theta$ — it does not specify a full probability distribution.

## Change

Reworded the section so quasi-Poisson is framed as an *inference method* (defined by a mean–variance relationship), explicitly distinguished from a model *structure* (a full distributional family) like the negative binomial. Preserves the author's voice and the `?quasipoisson` pointer.

## Verification

Prose-only edit — no R code, macros, or new spell-check words (`quasipoisson` and `\Var{Y}` already appear in this file). Lint and spell are unaffected; CI re-validates rendering. (Local full render isn't feasible in this fresh container due to an unpopulated `renv` library.)

This is one of two chapters surfaced by a structure/inference survey of the book's content chapters; the other (`logistic-regression.qmd`) is in a separate PR per the per-chapter request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NHtAdoQEyFVdaPY4BbEJD

---
_Generated by [Claude Code](https://claude.ai/code/session_019NHtAdoQEyFVdaPY4BbEJD)_