### PR TITLE
logistic-regression: frame binomial→Poisson as a structure change, not a fitting workaround

### DIFF
--- a/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
+++ b/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
@@ -63,16 +63,16 @@ not finding good starting values for the estimation procedure.
 This is likely because the model is producing fitted probabilities greater than
 1.
 
-When this happens, you can instead switch the outcome distribution from
-binomial to Poisson and fit a Poisson regression model
+When this happens, you can instead switch the outcome distribution from binomial to Poisson,
+and fit a Poisson regression model
 (we will see those soon!).
-Note that this is a change in model *structure* — a different outcome
-distribution — not just a different way of fitting the same model.
-With a Poisson outcome distribution you won't get warnings about fitted
-probabilities greater than 1,
+Note that this is a change in model *structure* — a different outcome distribution —
+not just a different way of fitting the same model.
+With a Poisson outcome distribution,
+you won't get warnings about fitted probabilities greater than 1,
 but that distribution isn't quite right for binary outcomes.
-In my opinion, the Poisson model for binary outcomes is
-confusing and not very appealing.
+In my opinion,
+the Poisson model for binary outcomes is confusing and not very appealing.
 
 ### WCGS: link functions
 

--- a/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
+++ b/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
@@ -63,10 +63,12 @@ not finding good starting values for the estimation procedure.
 This is likely because the model is producing fitted probabilities greater than
 1.
 
-When this happens, you can instead switch the outcome distribution from binomial to Poisson,
+When this happens,
+you can instead switch the outcome distribution from binomial to Poisson
 and fit a Poisson regression model
 (we will see those soon!).
-Note that this is a change in model *structure* — a different outcome distribution —
+Note that this is a change in model *structure* —
+a different outcome distribution —
 not just a different way of fitting the same model.
 With a Poisson outcome distribution,
 you won't get warnings about fitted probabilities greater than 1,

--- a/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
+++ b/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
@@ -63,11 +63,14 @@ not finding good starting values for the estimation procedure.
 This is likely because the model is producing fitted probabilities greater than
 1.
 
-When this happens, you can try to fit Poisson regression models instead
+When this happens, you can instead switch the outcome distribution from
+binomial to Poisson and fit a Poisson regression model
 (we will see those soon!).
-But then the outcome distribution isn't quite
-right, and you won't get warnings about fitted probabilities greater
-than 1.
+Note that this is a change in model *structure* — a different outcome
+distribution — not just a different way of fitting the same model.
+With a Poisson outcome distribution you won't get warnings about fitted
+probabilities greater than 1,
+but that distribution isn't quite right for binary outcomes.
 In my opinion, the Poisson model for binary outcomes is
 confusing and not very appealing.
 


### PR DESCRIPTION
## What

Applies the **model structure vs. inference method** convention (CLAUDE.md → Content Writing) to `chapters/logistic-regression.qmd` (via its subfile `_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd`).

When the log-link binomial GLM fails to converge, the text suggested you "can try to fit Poisson regression models instead," framing it as just another fitting recipe. But switching from a binomial to a Poisson outcome distribution is a change of **model structure**, not a fitting workaround — the structural cost was mentioned only in passing.

## Change

Reworded the troubleshooting note so the change of *model structure* (binomial → Poisson outcome distribution) is explicit and clearly distinguished from the *fitting method*. Preserves the author's voice (including the "confusing and not very appealing" aside).

## Verification

Prose-only edit inside a `notes`/example subfile — no R code, macros, or new spell-check words. Lint and spell are unaffected; CI re-validates rendering of the parent `logistic-regression.qmd`. (Local full render isn't feasible in this fresh container due to an unpopulated `renv` library.)

Adding the **clear freezer** label since a `_subfiles/` file was edited.

This is the second of two chapters surfaced by a structure/inference survey of the book's content chapters; the other (`count-regression.qmd`) is #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NHtAdoQEyFVdaPY4BbEJD

---
_Generated by [Claude Code](https://claude.ai/code/session_019NHtAdoQEyFVdaPY4BbEJD)_