### PR TITLE
Refresh CLAUDE.md to current repo state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,10 @@ Before committing any `.qmd`, `.R`, or config file change:
 - Link to `.qmd` source files, not rendered `.html` files
 - Aim to keep `.qmd` source files under ~100 lines; split longer files into named subfiles in `_subfiles/`
 - `_extensions/` is vendored third-party code — do not review or modify it
-- New book pages must be wired into **both** `_quarto-book.yml` (book/PDF TOC, incl. its `part:` groupings) **and** `_quarto-website.yml` (the default website profile: the `render:` list **and** the navbar) — the two profiles keep independent page lists, so a page added to only one is missing from the other build
+- New book pages must be wired into each render profile that should include them — the profiles keep independent page lists, so a page added to only one is missing from the others:
+  - `_quarto-website.yml` — the default profile (`profile.default: website` in `_quarto.yml`): add to the `render:` list **and** the navbar
+  - `_quarto-book.yml` — the book/PDF TOC, incl. its `part:` groupings
+  - `_quarto-handout.yml` — a curated PDF-handout subset with its own `render:` list; add the page here too if it belongs in the handouts
 
 ### Quarto
 - Use `{{< slidebreak >}}` instead of `---` for slide breaks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Before committing any `.qmd`, `.R`, or config file change:
 - Aim to keep `.qmd` source files under ~100 lines; split longer files into named subfiles in `_subfiles/`
 - `_extensions/` is vendored third-party code — do not review or modify it
 - New book pages must be wired into each render profile that should include them — the profiles keep independent page lists, so a page added to only one is missing from the others:
-  - `_quarto-website.yml` — the default profile (`profile.default: website` in `_quarto.yml`): add to the `render:` list **and** the navbar
+  - `_quarto-website.yml` — the default profile (`profile.default: website` in `_quarto.yml`): add to the `render:` list, and to the navbar if it's a primary/navigable chapter (supplemental pages like appendices can stay in `render:` without a navbar entry)
   - `_quarto-book.yml` — the book/PDF TOC: add to `book.chapters:` (directly or inside a `part:` grouping)
   - `_quarto-handout.yml` — a curated PDF-handout subset with its own `render:` list; add the page here too if it belongs in the handouts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Before committing any `.qmd`, `.R`, or config file change:
 - `_extensions/` is vendored third-party code — do not review or modify it
 - New book pages must be wired into each render profile that should include them — the profiles keep independent page lists, so a page added to only one is missing from the others:
   - `_quarto-website.yml` — the default profile (`profile.default: website` in `_quarto.yml`): add to the `render:` list **and** the navbar
-  - `_quarto-book.yml` — the book/PDF TOC, incl. its `part:` groupings
+  - `_quarto-book.yml` — the book/PDF TOC: add to `book.chapters:` (directly or inside a `part:` grouping)
   - `_quarto-handout.yml` — a curated PDF-handout subset with its own `render:` list; add the page here too if it belongs in the handouts
 
 ### Quarto


### PR DESCRIPTION
## What

The page-wiring note in `CLAUDE.md` listed only two render profiles, `_quarto-book.yml` and `_quarto-website.yml`. The repo actually has a third profile, `_quarto-handout.yml`, with its own independent `render:` list (a curated PDF-handout subset). A page added to only the website/book lists is silently dropped from the handouts build.

This updates the **File Structure** bullet to cover all three profiles, so the wiring guidance matches reality.

## Why this is the only change

I surveyed the rest of the file against the current repo and found no other drift: the build/lint/spell commands, the `latex-macros/macros.qmd` macro path (in the `latex-macros` submodule), `_extensions/`, `inst/WORDLIST`, and the renv/cross-reference/citation conventions all still match. So this is a single targeted edit, not a rewrite.

Per this repo's reporting convention, references link to GitHub — e.g. [#915](https://github.com/d-morrison/rme/pull/915).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P5jndYuYhLVGPp1e9CEcp

---
_Generated by [Claude Code](https://claude.ai/code/session_012P5jndYuYhLVGPp1e9CEcp)_