### PR TITLE
Add Proof Writing appendix

### DIFF
--- a/_quarto-book.yml
+++ b/_quarto-book.yml
@@ -58,6 +58,7 @@ book:
     - chapters/bayesian-examples.qmd
     - chapters/common-mistakes.qmd
     - chapters/notation.qmd
+    - chapters/proof-writing.qmd
     - chapters/package-versions.qmd
     - chapters/intro-to-R.qmd
     - chapters/CONTRIBUTING.qmd

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -36,6 +36,7 @@ project:
     - chapters/bayesian-examples.qmd
     - chapters/common-mistakes.qmd
     - chapters/notation.qmd
+    - chapters/proof-writing.qmd
     - chapters/intro-to-R.qmd
     - chapters/CONTRIBUTING.qmd
     - chapters/exam-formula-sheet.qmd
@@ -133,6 +134,8 @@ website:
             href: chapters/common-mistakes.qmd
           - text: "Notation"
             href: chapters/notation.qmd
+          - text: "Proof Writing"
+            href: chapters/proof-writing.qmd
           - text: "Introduction to R"
             href: chapters/intro-to-R.qmd
           - text: "Exam Formula Sheet"

--- a/chapters/notation.qmd
+++ b/chapters/notation.qmd
@@ -93,9 +93,12 @@ We can use any of:
 - $\Rightarrow$ (`\Rightarrow`), 
 - $\models$ (`\models`) 
 
-to denote logical entailments (deductive consequences). 
+to denote logical entailments (deductive consequences).
 
 Let's save $\rightarrow$ (`\rightarrow`) for convergence results.
+
+See [Proof Writing](proof-writing.qmd)
+for general guidance on how to present proofs and derivations.
 
 
 # Stochastic vs. probabilistic vs. random {#sec-stochastic-probabilistic-random}

--- a/chapters/notation.qmd
+++ b/chapters/notation.qmd
@@ -100,7 +100,6 @@ Let's save $\rightarrow$ (`\rightarrow`) for convergence results.
 See [Proof Writing](proof-writing.qmd)
 for general guidance on how to present proofs and derivations.
 
-
 # Stochastic vs. probabilistic vs. random {#sec-stochastic-probabilistic-random}
 
 {{< include _subfiles/notation/_sec-stochastic-probabilistic-random.qmd >}}

--- a/chapters/proof-writing.qmd
+++ b/chapters/proof-writing.qmd
@@ -1,0 +1,84 @@
+---
+title: "Proof Writing"
+format:
+  html: default
+  revealjs:
+    output-file: proof-writing-slides.html
+  pdf:
+    output-file: proof-writing-handout.pdf
+  docx:
+    output-file: proof-writing-handout.docx
+
+---
+
+{{< include latex-macros/macros.qmd >}}
+
+This appendix collects some general advice on how to write proofs and derivations.
+The goal of a proof is not just to convince yourself that a result is true;
+it is to convince a *reader*,
+and to show them *why* it is true.
+The principles below all serve that goal.
+
+# Don't skip steps
+
+Show every step of the derivation.
+Each line should follow from the previous line by a single, identifiable move:
+applying a definition,
+substituting a known result,
+or performing one algebraic operation.
+
+When you skip steps,
+you force the reader to reconstruct your reasoning,
+which is exactly the work the proof was supposed to do *for* them.
+A step that feels "obvious" while you are writing it
+is often the step a reader gets stuck on.
+Phrases like "it can be shown that" or "clearly"
+are usually a sign that a step is being skipped;
+prefer to show it instead.
+
+# Annotate each step
+
+For each step,
+note the definition, theorem, or algebraic rule that justifies it.
+A brief annotation to the right of the line is usually enough.
+This makes the proof checkable,
+and it teaches the reader which tool to reach for in similar situations.
+
+For example,
+here is a derivation of the identity $\var{X} = \E{X^2} - \sqf{\E{X}}$,
+with each step annotated:
+
+$$
+\ba
+\var{X}
+&= \E{\sqf{X - \E{X}}}
+&& \text{(definition of variance)}
+\\
+&= \E{X^2 - 2 X \E{X} + \sqf{\E{X}}}
+&& \text{(expand the square)}
+\\
+&= \E{X^2} - \E{2 X \E{X}} + \E{\sqf{\E{X}}}
+&& \text{(linearity of expectation)}
+\\
+&= \E{X^2} - 2 \E{X} \E{X} + \sqf{\E{X}}
+&& \text{(}\E{X}\text{ is a constant)}
+\\
+&= \E{X^2} - 2 \sqf{\E{X}} + \sqf{\E{X}}
+&& \text{(collect like terms)}
+\\
+&= \E{X^2} - \sqf{\E{X}}
+&& \text{(simplify)}
+\ea
+$$
+
+# Follow the golden rule
+
+In general,
+follow the golden rule:
+treat your readers the way you want to be treated as a reader.
+
+When you read someone else's proof,
+you want to be able to follow every step without guessing,
+to know which result is being used at each line,
+and to never be left wondering where a quantity came from.
+Write your own proofs to meet that same standard.

--- a/chapters/proof-writing.qmd
+++ b/chapters/proof-writing.qmd
@@ -19,7 +19,7 @@ it is to convince a *reader*,
 and to show them *why* it is true.
 The principles below all serve that goal.
 
-# Don't skip steps
+# Don't skip steps {#sec-dont-skip-steps}
 
 Show every step of the derivation.
 Each line should follow from the previous line by a single, identifiable move:
@@ -36,7 +36,7 @@ Phrases like "it can be shown that" or "clearly"
 are usually a sign that a step is being skipped;
 prefer to show it instead.
 
-# Annotate each step
+# Annotate each step {#sec-annotate-each-step}
 
 For each step,
 note the definition, theorem, or algebraic rule that justifies it.
@@ -64,14 +64,14 @@ $$
 && \text{(}\E{X}\text{ is a constant)}
 \\
 &= \E{X^2} - 2 \sqf{\E{X}} + \sqf{\E{X}}
-&& \text{(collect like terms)}
+&& \text{(}\E{X}\E{X} = \sqf{\E{X}}\text{)}
 \\
 &= \E{X^2} - \sqf{\E{X}}
-&& \text{(simplify)}
+&& \text{(collect like terms)}
 \ea
 $$
 
-# Follow the golden rule
+# Follow the golden rule {#sec-golden-rule}
 
 In general,
 follow the golden rule:


### PR DESCRIPTION
## Summary

Adds a new appendix chapter, `chapters/proof-writing.qmd`, with general guidance on how to write proofs and derivations:

- **Don't skip steps** — each line should follow from the previous one by a single, identifiable move.
- **Annotate each step** — note the definition, theorem, or algebraic rule that justifies it (illustrated with a fully annotated derivation of $\mathrm{Var}(X) = E[X^2] - (E[X])^2$).
- **Follow the golden rule** — treat your readers the way you want to be treated as a reader.

This formalizes guidance that the book already follows in practice (e.g. the all-steps-shown derivations in the estimation chapters) and that lived implicitly in `CONTRIBUTING.qmd` and the brief "Proofs" section of the Notation appendix.

## Wiring

The new page is registered in **both** quarto profiles:

- `_quarto-book.yml` — added to the `appendices:` list (after Notation).
- `_quarto-website.yml` — added to the `render:` list **and** the Appendices navbar menu.

The "Proofs" section of `chapters/notation.qmd` now cross-links to the new page.

## Verification

- `quarto render chapters/proof-writing.qmd --to html` — ✅ builds
- `quarto render chapters/notation.qmd --to html` — ✅ builds (cross-link added)
- `lintr::lint()` on both changed `.qmd` files — ✅ no lints
- `spelling::spell_check_package()` — ✅ no spelling errors

## Notes

This was prompted by a request to add a general note on proof writing as its own appendix chapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143ufpNxvo7rzdtUDLVsXuN

---
_Generated by [Claude Code](https://claude.ai/code/session_0143ufpNxvo7rzdtUDLVsXuN)_