### PR TITLE
Add integration-region figures and cross-reference all Fubini figures

### DIFF
--- a/_subfiles/math-prereqs/_sec_double_integrals.qmd
+++ b/_subfiles/math-prereqs/_sec_double_integrals.qmd
@@ -133,10 +133,37 @@ two iterated forms shown.
 Adapted from [@larsonCalc11e, Section 14.2, Example 2, pp. 982--983].
 
 Evaluate $\displaystyle\iint_R \paren{1 - \frac{1}{2}x^2 - \frac{1}{2}y^2}\,dA$
-on the unit square $R = \{(x, y) : 0 \le x \le 1,\; 0 \le y \le 1\}$.
+on the unit square $R = \{(x, y) : 0 \le x \le 1,\; 0 \le y \le 1\}$
+(@fig-fubini-rect-region).
 
 The integrand is continuous on $R$, so @cor-fubini-rect applies and
 either order of integration yields the same value.
+
+:::{#fig-fubini-rect-region}
+
+```{r}
+#| code-fold: true
+#| message: false
+
+ggplot2::ggplot() +
+  ggplot2::geom_rect(
+    ggplot2::aes(xmin = 0, xmax = 1, ymin = 0, ymax = 1),
+    fill = "steelblue", alpha = 0.4, color = "black", linewidth = 0.7
+  ) +
+  ggplot2::annotate(
+    "text", x = 0.5, y = 0.5, label = "R", size = 8, fontface = "italic"
+  ) +
+  ggplot2::scale_x_continuous(breaks = c(0, 1), limits = c(-0.15, 1.25)) +
+  ggplot2::scale_y_continuous(breaks = c(0, 1), limits = c(-0.15, 1.25)) +
+  ggplot2::coord_equal() +
+  ggplot2::labs(x = "x", y = "y") +
+  ggplot2::theme_minimal()
+```
+
+Integration region $R = [0, 1]^2$ for @exm-fubini-rect.
+
+:::
+
 
 **Integrating $y$ first, then $x$** (the order Larson chooses):
 
@@ -162,6 +189,7 @@ $$
 $$
 
 Both orders give $\frac{2}{3}$, as @cor-fubini-rect guarantees.
+The solid is shown in @fig-fubini-rect.
 
 :::{#fig-fubini-rect}
 
@@ -203,10 +231,48 @@ Find the volume of the solid bounded by the surface $z = \ef{-x^2}$
 and the planes $z = 0$, $y = 0$, $y = x$, and $x = 1$.
 
 The base of the solid in the $xy$-plane is the triangular region
-$D = \{(x, y) : 0 \le x \le 1,\; 0 \le y \le x\}$,
+$D = \{(x, y) : 0 \le x \le 1,\; 0 \le y \le x\}$
+(@fig-fubini-nonrect-region),
 so the volume is
 
 $$\iint_D \ef{-x^2}\,dA.$$
+
+:::{#fig-fubini-nonrect-region}
+
+```{r}
+#| code-fold: true
+#| message: false
+
+region <- data.frame(x = c(0, 1, 1), y = c(0, 0, 1))
+ggplot2::ggplot(region, ggplot2::aes(x = x, y = y)) +
+  ggplot2::geom_polygon(
+    fill = "steelblue", alpha = 0.4, color = "black", linewidth = 0.7
+  ) +
+  ggplot2::annotate(
+    "text", x = 0.65, y = 0.28, label = "D", size = 8, fontface = "italic"
+  ) +
+  ggplot2::annotate(
+    "text", x = 0.36, y = 0.52, label = "y == x",
+    parse = TRUE, angle = 45
+  ) +
+  ggplot2::annotate(
+    "text", x = 1.08, y = 0.5, label = "x == 1",
+    parse = TRUE, angle = 90, hjust = 0.5
+  ) +
+  ggplot2::annotate(
+    "text", x = 0.5, y = -0.1, label = "y == 0", parse = TRUE
+  ) +
+  ggplot2::scale_x_continuous(breaks = c(0, 0.5, 1), limits = c(-0.1, 1.3)) +
+  ggplot2::scale_y_continuous(breaks = c(0, 0.5, 1), limits = c(-0.2, 1.2)) +
+  ggplot2::coord_equal() +
+  ggplot2::labs(x = "x", y = "y") +
+  ggplot2::theme_minimal()
+```
+
+Triangular integration region $D = \{(x, y) : 0 \le y \le x \le 1\}$,
+bounded below by $y = 0$, above-left by $y = x$, and on the right by $x = 1$.
+
+:::
 
 **Order $dx\,dy$ is intractable.** Re-describing $D$ as
 $D = \{(x, y) : 0 \le y \le 1,\; y \le x \le 1\}$, the inner integral is
@@ -231,6 +297,8 @@ $$
 \\&\approx 0.316
 \ea
 $$
+
+The solid is shown in @fig-fubini-nonrect.
 
 :::{#fig-fubini-nonrect}
 
@@ -344,6 +412,8 @@ $$
 since $\int_0^{\epsilon} dr/r$ diverges.
 
 [@wp:fubini]
+
+The surface is shown in @fig-fubini-fail.
 
 :::{#fig-fubini-fail}
 


### PR DESCRIPTION
## Summary

The Fubini examples in the double-integrals section
(`_subfiles/math-prereqs/_sec_double_integrals.qmd`) describe
non-trivial integration regions but did not graph them, and their
existing 3D surface figures were never referenced from the prose. This
PR addresses both, per the request to "graph the integration region"
and ensure "all figures and tables should be discussed and
cross-referenced in the prose."

## Changes

- **`@exm-fubini-nonrect`** — Added `@fig-fubini-nonrect-region`: a 2D
  ggplot2 graph of the triangular integration region
  $D = \{(x,y): 0 \le y \le x \le 1\}$, with its bounding lines
  $y=0$, $y=x$, and $x=1$ labeled. Referenced in the prose where $D$ is
  first defined.
- **`@exm-fubini-rect`** — Added `@fig-fubini-rect-region`: a 2D graph of
  the unit-square region $R = [0,1]^2$. Referenced in the problem
  statement.
- **Cross-references** — Every figure is now discussed in the prose: the
  two new region figures where each region is introduced, and the three
  existing 3D surface figures (`@fig-fubini-rect`, `@fig-fubini-nonrect`,
  `@fig-fubini-fail`) at the point each solid/surface is discussed.

## Verification

- ✅ `quarto render chapters/math-prereqs.qmd --to html` — succeeds; all
  five `fig-fubini-*` IDs and cross-references resolve (the only warning,
  `@sec-infer-LMs`, is a pre-existing cross-chapter reference unrelated to
  this change).
- ✅ `lintr::lint()` on the changed subfile — no lints.
- ✅ `spelling::spell_check_package()` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhBGojpHP6Ebh5x3RszwLV)_