### PR TITLE
Fix @claude review re-dispatch: allow github-actions[bot] in claude-code-review.yml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -127,6 +127,20 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Permit github-actions[bot] to initiate this run. claude.yml
+          # re-dispatches a review via `gh workflow run` (workflow_dispatch),
+          # which runs as github-actions[bot]. In agent mode — which
+          # workflow_dispatch uses (track_progress is 'false' below for
+          # dispatched runs) — the action blocks bot actors by default and
+          # aborts with "Workflow initiated by non-human actor: github-actions
+          # ... Add bot to allowed_bots". Without this, every @claude-review
+          # re-dispatch (and the post-commit re-dispatch) dies before it can
+          # post a review (observed on PR #706 run 28257175025). The job-level
+          # `if:` already filters bots off the automatic pull_request path, so
+          # this only widens the dispatch path, itself reachable only via
+          # claude.yml's trusted-author gate. Mirrors the allowed-bots default
+          # in the canonical d-morrison/gha reusable workflow.
+          allowed_bots: "github-actions[bot]"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |


### PR DESCRIPTION
## Problem

`@claude review` comments produced no review. On [PR #706](https://github.com/d-morrison/rme/pull/706) the [`@claude review` comment](https://github.com/d-morrison/rme/pull/706#issuecomment-4812178258) was acknowledged but no review followed.

The pipeline fires correctly: `claude.yml` runs and re-dispatches `claude-code-review.yml` via `workflow_dispatch`. But that dispatched run ([#28257175025](https://github.com/d-morrison/rme/actions/runs/28257175025)) **failed in ~6 s** in *Run Claude Code Review*:

```
Actor type: Bot
##[error]Action failed with error: Workflow initiated by non-human actor:
github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

`anthropics/claude-code-action@v1` aborts on a bot-initiated trigger unless `allowed_bots` lists the bot. The re-dispatch runs as `github-actions[bot]`, and this standalone workflow never set `allowed_bots` — so every `@claude review` re-dispatch (and the post-commit re-dispatch) died before posting.

## Fix

Add `allowed_bots: "github-actions[bot]"` to the *Run Claude Code Review* step, mirroring the canonical [`d-morrison/gha`](https://github.com/d-morrison/gha/blob/main/.github/workflows/claude-code-review.yml) reusable workflow, which already carries this fix (its `allowed-bots` input defaults to the same value). The job-level `if:` still filters bots off the automatic `pull_request` path, so this only widens the dispatch path — reachable only via `claude.yml`'s trusted-author gate.

## Scope

One-line config addition (plus explaining comment). No behavior change on the `pull_request` path.

## Follow-up

This standalone copy has diverged from the `gha` reusable workflow (that's how it missed the fix). Replacing it with a thin caller of `gha`'s `claude-code-review.yml@v1` is tracked separately so it can't drift again.

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQfvkBFv1wcmY7p4SUAxHK)_