### PR TITLE
Fix cross-chapter @def-coef-interp-procedure references

### DIFF
--- a/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
+++ b/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
@@ -7,7 +7,7 @@ derive interpretations of $\beta_0$, $\beta_P$, $\beta_A$, and $\beta_{PA}$
 on the odds **and** log-odds scales, 
 State the interpretations concisely in math **and** in words.
 
-*(Hint: apply @def-coef-interp-procedure to the log-odds linear predictor $\eta(\vx) = \logit(\pi(\vx))$.)*
+*(Hint: apply the [general procedure for interpreting a regression coefficient](Linear-models-overview.qmd#def-coef-interp-procedure) to the log-odds linear predictor $\eta(\vx) = \logit(\pi(\vx))$.)*
 
 :::
 

--- a/_subfiles/logistic-regression/_sec_derivs_MLE.qmd
+++ b/_subfiles/logistic-regression/_sec_derivs_MLE.qmd
@@ -2,7 +2,7 @@
 
 :::{.callout-note}
 
-See @def-coef-interp-procedure for the full procedure, including how to handle interaction terms and how to set remaining covariates to their reference values.
+See the [general procedure for interpreting a regression coefficient](Linear-models-overview.qmd#def-coef-interp-procedure) for full details, including how to handle interaction terms and how to set remaining covariates to their reference values.
 
 **In order to interpret $\beta_j$**:
 differentiate or difference $\red{\eta(\vx)}$ with respect to $\red{x_j}$ (depending on whether $x_j$ is continuous or discrete, respectively):

--- a/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
+++ b/_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd
@@ -278,7 +278,7 @@ $$
 
 {{< slidebreak >}}
 
-Applying @def-coef-interp-procedure to the log-hazard linear predictor $\eta(\vx) = \diffloghaz(\vx) = \reglincomb$ (differentiating or differencing with respect to $x_j$, depending on whether $x_j$ is continuous or discrete, with all other covariates held fixed) yields the following interpretation of $\b_j$:
+Applying the [general procedure for interpreting a regression coefficient](Linear-models-overview.qmd#def-coef-interp-procedure) to the log-hazard linear predictor $\eta(\vx) = \diffloghaz(\vx) = \reglincomb$ (differentiating or differencing with respect to $x_j$, depending on whether $x_j$ is continuous or discrete, with all other covariates held fixed) yields the following interpretation of $\b_j$:
 
 If only one covariate $x_j$ is changing, then:
 


### PR DESCRIPTION
## Problem

`@def-coef-interp-procedure` is defined in the **Linear-models-overview** chapter (`_subfiles/Linear-models-overview/_sec_linreg_coef_interp_procedure.qmd`). Because this is a Quarto **website** project (not a book), `@id` cross-references do **not** resolve across separate `.html` files, so these usages render as the literal broken text `?@def-coef-interp-procedure`.

## Fix

Replace each cross-chapter `@def-coef-interp-procedure` with an explicit relative link to the hosting chapter (`Linear-models-overview.qmd#def-coef-interp-procedure`), per the repo's [cross-chapter reference convention](CLAUDE.md):

- `_subfiles/logistic-regression/_sec_derivs_MLE.qmd`
- `_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd`
- `_subfiles/proportional-hazards-models/_sec-understand-coxph.qmd`

## Context

The same broken reference in the **count-regression** chapter (`_subfiles/count-regression/_sec_poisson_RRs.qmd`) is fixed in [#860](https://github.com/d-morrison/rme/pull/860), where it was first spotted in the rendered preview. This PR cleans up the remaining three occurrences in the other chapters so the whole repo is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYf8XrzEWCDWht1YSHWqZc)_