### PR TITLE
ci: pin gha reusable workflows to @v2 (v1 is frozen)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,7 @@ jobs:
       issues: write
       id-token: write
       actions: read # lets the reviewer read CI status (github_ci MCP server)
-    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v1
+    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v2
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }} # for the private latex-macros submodule

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v1
+    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -21,4 +21,4 @@ jobs:
       contents: write        # push to gh-pages
       pull-requests: write   # post the preview-link comment
       actions: read          # download the build artifact
-    uses: d-morrison/gha/.github/workflows/preview-deploy.yml@v1
+    uses: d-morrison/gha/.github/workflows/preview-deploy.yml@v2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,6 +38,6 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: d-morrison/gha/.github/workflows/preview.yml@v1
+    uses: d-morrison/gha/.github/workflows/preview.yml@v2
     with:
       r-version: '4.6.0'


### PR DESCRIPTION
## Why

rme calls four `d-morrison/gha` reusable workflows at **`@v1`**, but `v1` is **frozen**: gha cut a `v2.0.0` release, and its `slide-major-tag` workflow advances *the latest semver major* — so it now slides **`v2`** and leaves `v1` stuck at `8ad0b14` (gha#116). rme on `@v1` therefore no longer receives any gha updates or fixes.

## What

Bump all four pins `@v1` → `@v2`:
- `.github/workflows/claude-code-review.yml`
- `.github/workflows/cleanup-pr-previews.yml`
- `.github/workflows/preview-deploy.yml`
- `.github/workflows/preview.yml`

## Safety

I diffed the `workflow_call` interfaces (inputs/secrets) of all four reusable workflows between `v1` and `v2` — they are **identical**, so this is a no-caller-change version bump. It moves rme onto the active gha line and picks up current behavior, including the preview-comment bump fix ([d-morrison/gha#129](https://github.com/d-morrison/gha/pull/129)).

Verified via `git ls-remote`: `v2` currently points at gha `main` and **includes #129**, so this migration delivers that fix immediately on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)