### PR TITLE
docs: update \v macro guidance now that it is fixed in macros.qmd

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -593,8 +593,8 @@ Key macros to use:
   write `\hat{\vec{\mu}}`, not `\vec{\hat\mu}`. The hat sits on top of the
   already-vectorized symbol. Use `\v{}`, `\vec{}`, or `\vecf{}` — all three
   work. (`\v` was formerly broken because `\providecommand` could not override
-  the LaTeX built-in caron accent; it is now defined with `\def` in
-  `macros.qmd`.)
+  the LaTeX built-in caron accent; it is now defined with `\renewcommand`
+  in `macros.qmd`.)
 
 matrix-product helper macros:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -591,10 +591,10 @@ Key macros to use:
 - **Estimators of vector estimands**: the estimator symbol (e.g. `\hat`,
   `\bar`, `\tilde`) goes on top of the vector symbol, not inside it —
   write `\hat{\vec{\mu}}`, not `\vec{\hat\mu}`. The hat sits on top of the
-  already-vectorized symbol. Use `\vec{}` or `\vecf{}`, **not** `\v{}`: `\v`
-  is a LaTeX built-in (the caron accent), so `\providecommand{\v}{...}` in
-  `macros.qmd` is a no-op and `\hat{\v{\mu}}` renders as a broken red `\v`
-  in MathJax.
+  already-vectorized symbol. Use `\v{}`, `\vec{}`, or `\vecf{}` — all three
+  work. (`\v` was formerly broken because `\providecommand` could not override
+  the LaTeX built-in caron accent; it is now defined with `\def` in
+  `macros.qmd`.)
 
 matrix-product helper macros:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,9 @@ Before committing any `.qmd`, `.R`, or config file change:
 - Estimators of vector estimands: the estimator symbol (e.g. `\hat`) goes
   on top of the vector symbol, not inside it — write `\hat{\vec{\mu}}`, not
   `\vec{\hat\mu}`. (Same for `\bar`, `\tilde`, etc.) Use `\vec{}` or `\vecf{}`,
-  **not** `\v{}`: `\v` is a LaTeX built-in (the caron accent), so
-  `\providecommand{\v}{...}` in `macros.qmd` is a no-op and `\hat{\v{\mu}}`
-  renders as a broken red `\v` in MathJax.
+  `\v{}`, `\vec{}`, or `\vecf{}` all work — `\v` was formerly broken
+  (its `\providecommand` definition was a no-op against the LaTeX built-in
+  caron accent) but is now defined with `\def` in `macros.qmd`.
 - Ratios vs. factors:
   - Use the generic `\ratio`/`\ratiof` macro when a ratio's inputs are the **quantities themselves** (the odds, hazards, rates, etc.) — e.g. `\ratio(\odds_1, \odds_2)`, **not** `\ror(\odds_1, \odds_2)` — because the type of ratio is clear from the inputs.
   - Use the type-subscripted ratio macros (`\ror` for odds ratios, `\hazratio`/`\hr` for hazard ratios, `\rateratio`, `\riskratio`, `\prevratio`, `\cuhazratio`, …) only when the inputs are **covariate patterns** (e.g. `\ror(\vx,\vxs)`, `\hr(t\mid\vx:\vxs)`), where the subscript is needed to say which kind of ratio it is.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,10 @@ Before committing any `.qmd`, `.R`, or config file change:
 - **Jacobian**: `\deriv{\vb} \vx` where both are p-vectors produces a p × p Jacobian matrix (not a vector)
 - Estimators of vector estimands: the estimator symbol (e.g. `\hat`) goes
   on top of the vector symbol, not inside it — write `\hat{\vec{\mu}}`, not
-  `\vec{\hat\mu}`. (Same for `\bar`, `\tilde`, etc.) Use `\vec{}` or `\vecf{}`,
-  `\v{}`, `\vec{}`, or `\vecf{}` all work — `\v` was formerly broken
-  (its `\providecommand` definition was a no-op against the LaTeX built-in
-  caron accent) but is now defined with `\def` in `macros.qmd`.
+  `\vec{\hat\mu}`. (Same for `\bar`, `\tilde`, etc.) Use `\v{}`, `\vec{}`, or
+  `\vecf{}` — all three work. (`\v` was formerly broken because its
+  `\providecommand` definition was a no-op against the LaTeX built-in caron
+  accent; it is now defined with `\renewcommand` in `macros.qmd`.)
 - Ratios vs. factors:
   - Use the generic `\ratio`/`\ratiof` macro when a ratio's inputs are the **quantities themselves** (the odds, hazards, rates, etc.) — e.g. `\ratio(\odds_1, \odds_2)`, **not** `\ror(\odds_1, \odds_2)` — because the type of ratio is clear from the inputs.
   - Use the type-subscripted ratio macros (`\ror` for odds ratios, `\hazratio`/`\hr` for hazard ratios, `\rateratio`, `\riskratio`, `\prevratio`, `\cuhazratio`, …) only when the inputs are **covariate patterns** (e.g. `\ror(\vx,\vxs)`, `\hr(t\mid\vx:\vxs)`), where the subscript is needed to say which kind of ratio it is.


### PR DESCRIPTION
## Summary

- `CLAUDE.md` and `.github/copilot-instructions.md` both warned authors to avoid `\v{}` because its `\providecommand` definition in `macros.qmd` was a no-op against the LaTeX built-in caron accent.
- Now that `macros.qmd` defines `\v` with `\renewcommand` (see d-morrison/macros#68), `\v{}` works correctly alongside `\vec{}` and `\vecf{}`.
- Update both doc files to remove the warning and describe all three aliases as valid.
- Bumps the `latex-macros` submodule pointer to include the fix.

Fixes #950.