### PR TITLE
Split risk-set definition into "risk set" and "number at risk"

### DIFF
--- a/_subfiles/intro-to-survival-analysis/_def-risk-set.qmd
+++ b/_subfiles/intro-to-survival-analysis/_def-risk-set.qmd
@@ -12,12 +12,6 @@ $$\mathcal{R}(t) \;\eqdef\; \bigl\{i \in \{1, \ldots, n\} : \tilde{T}_i \geq t\b
 the set of subjects still under observation (neither having experienced
 the event nor been censored) immediately before time $t$.
 
-The **number at risk at time $t$** is
-
-$$r(t) \;\eqdef\; \lvert \mathcal{R}(t) \rvert.$$
-
-At each ordered event time $t_i$, this count is written $r_i \eqdef r(t_i)$.
-
 :::
 
 ::: {#exm-risk-set-cartoon}
@@ -25,6 +19,26 @@ At each ordered event time $t_i$, this count is written $r_i \eqdef r(t_i)$.
 In @fig-risk-set-dropout-cartoon, the 8-person study has
 $\tilde{T}_i \in \{2, 3, 4, 5, 6, 6, 7, 8\}$.
 At time $t = 4$, subjects 3, 4, 5, 6, 7, and 8 still have
-$\tilde{T}_i \geq 4$, so $\mathcal{R}(4) = \{3, 4, 5, 6, 7, 8\}$ and
-$r(4) = 6$.
+$\tilde{T}_i \geq 4$, so $\mathcal{R}(4) = \{3, 4, 5, 6, 7, 8\}$.
+:::
+
+{{< slidebreak >}}
+
+:::{#def-number-at-risk}
+#### Number at Risk
+
+The **number at risk at time $t$** is
+
+$$r(t) \;\eqdef\; \lvert \mathcal{R}(t) \rvert,$$
+
+the size of the risk set $\mathcal{R}(t)$ (@def-risk-set).
+At each ordered event time $t_i$, this count is written $r_i \eqdef r(t_i)$.
+
+:::
+
+::: {#exm-number-at-risk-cartoon}
+
+Continuing @exm-risk-set-cartoon, at time $t = 4$ the risk set is
+$\mathcal{R}(4) = \{3, 4, 5, 6, 7, 8\}$, so the number at risk is
+$r(4) = \lvert \mathcal{R}(4) \rvert = 6$.
 :::


### PR DESCRIPTION
## What

`def-risk-set` in `_subfiles/intro-to-survival-analysis/_def-risk-set.qmd` bundled two distinct concepts in one definition div:

- the **risk set** $\mathcal{R}(t)$ — a set of subjects, and
- the **number at risk** $r(t) = |\mathcal{R}(t)|$ — a count.

This PR splits them into two definitions so each can be cross-referenced independently:

- `def-risk-set` now defines only the risk set $\mathcal{R}(t)$.
- `def-number-at-risk` (new) defines $r(t)$ and references the risk set via `@def-risk-set`.

The cartoon example is split to match:

- `exm-risk-set-cartoon` shows the risk set $\mathcal{R}(4) = \{3,4,5,6,7,8\}$.
- `exm-number-at-risk-cartoon` (new) continues it to the count $r(4) = 6$.

## Verification

- `quarto render chapters/intro-to-survival-analysis.qmd --to html` — succeeds; the rendered page shows Definition 11 (Risk Set), Definition 12 (Number at Risk) linking back to Definition 11, Example 9 (risk set), and Example 10 ("Continuing Example 9…"). No broken `?@` cross-references.
- `lintr::lint()` on the changed file — no lints.
- `spelling::spell_check_package()` — no spelling errors.

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8VAGG2xvCD9UVAWrbf99q)_