### PR TITLE
fix: remove fig-format: svg from concept-map to fix CI

### DIFF
--- a/chapters/concept-map.qmd
+++ b/chapters/concept-map.qmd
@@ -77,7 +77,6 @@ Zoom in with Ctrl+scroll (or pinch on mobile) to read individual labels.
 #| fig-width: 50
 #| fig-height: 50
 #| out-width: "100%"
-#| fig-format: "svg"
 
 connected <- cg$nodes$id[cg$nodes$id %in% c(cg$edges$from, cg$edges$to)]
 core <- graph_from_data_frame(


### PR DESCRIPTION
## Summary

- Removes `#| fig-format: "svg"` from the `concept-map-ggraph` chunk in `chapters/concept-map.qmd`

## Root cause

The 50×50-inch SVG generated by ggraph/ggrepel was causing pandoc's HTML pass to fail silently (likely OOM-killed). With no `concept-map.html` produced, Quarto errored when trying to move the file to `_site`:

```
ERROR: NotFound: No such file or directory (os error 2):
  rename '.../chapters/concept-map.html' -> '.../chapters/_site/concept-map.html'
```

This has been breaking every publish run since the concept-map page was introduced in run 448 (commit that added the page).

## Fix

Remove the `fig-format: "svg"` override so knitr uses the default format per output type — PNG for HTML, PDF vector for PDF output. The 50×50-inch PNG at default resolution is a manageable file size and still supports browser zoom/pinch.

## Test plan

- [ ] CI publish workflow passes (concept-map.html is produced and moved to `_site`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BMtre98GTNp8m4tLTYSPLv)_