### PR TITLE
Enable gh-pages history compaction (closes #961)

### DIFF
--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,7 +1,9 @@
 # Housekeeping half of the PR-preview family, delegated to the reusable
 # workflow in d-morrison/gha. Periodically deletes gh-pages preview directories
-# for PRs that are no longer open. The calling job grants contents: write so the
-# reusable workflow can commit the deletions back to gh-pages.
+# for PRs that are no longer open, and (with compact-history) orphan-squashes
+# gh-pages to a single commit so the deleted snapshots stop bloating the repo.
+# The calling job grants contents: write so the reusable workflow can commit the
+# deletions / force-push the compacted branch back to gh-pages.
 name: Clean up PR Previews
 
 on:
@@ -15,3 +17,5 @@ jobs:
       contents: write
       pull-requests: read
     uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2
+    with:
+      compact-history: true


### PR DESCRIPTION
Sets `compact-history: true` on the existing `cleanup-pr-previews` reusable (d-morrison/gha#136). The weekly job now orphan-squashes `gh-pages` to a single commit after pruning closed-PR previews, instead of letting ~952 deleted full-book snapshots accumulate (~2.96 GB `.git` locally).

Branch-based Pages — stays compatible with the preview family; open-PR previews are preserved. Force-push uses `--force-with-lease` (retry-safe). Same fix as ucdavis/epi204#352.

After merge, one `workflow_dispatch` of **Clean up PR Previews** reclaims the existing history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)