### PR TITLE
HERS hygiene in the linear-regression chapter (phase 1 of #960)

### DIFF
--- a/_subfiles/Linear-models-overview/_sec_linreg_diag_direct_viz.qmd
+++ b/_subfiles/Linear-models-overview/_sec_linreg_diag_direct_viz.qmd
@@ -31,12 +31,9 @@ it becomes even harder to visualize the raw data.
 
 #### Fitted model for `hers` data {.smaller}
 
-::: notes
 Consider the `hers` data from @vittinghoff2e.
 
 {{< include _subfiles/shared/_sec_hers_intro.qmd >}}
-
-:::
 
 ::: {.landscape}
 

--- a/_subfiles/Linear-models-overview/_sec_linreg_model_selection.qmd
+++ b/_subfiles/Linear-models-overview/_sec_linreg_model_selection.qmd
@@ -762,8 +762,7 @@ See @rms2e and @heinze2018variable for more discussion.
 :::
 
 ```{r}
-library(olsrr)
-olsrr:::ols_step_both_aic(full_model)
+olsrr::ols_step_both_aic(full_model)
 ```
 
 ---

--- a/_subfiles/Linear-models-overview/_sec_linreg_ordinal.qmd
+++ b/_subfiles/Linear-models-overview/_sec_linreg_ordinal.qmd
@@ -35,7 +35,7 @@ instead of the default treatment contrasts:
 
 ```{r}
 hers <- hers |>
-  mutate(physact_ord = ordered(physact))
+  dplyr::mutate(physact_ord = ordered(physact))
 
 lm_physact <- lm(LDL ~ physact_ord, data = hers)
 ```
@@ -54,8 +54,10 @@ Mean LDL by physical-activity level, using polynomial contrasts
 
 With polynomial contrasts,
 each coefficient summarizes a trend component across the ordered levels:
-the linear term is the steady change in mean LDL per step up the scale,
+the linear term measures the strength and direction of a straight-line (monotone) trend in mean LDL across the levels,
 and the quadratic and higher terms capture curvature.
+The contrasts are orthonormal, so the linear coefficient is scaled by the contrast normalization;
+it is not the raw change in mean LDL per level.
 Here the linear-trend coefficient is small and not statistically significant,
 so these data show little evidence of a monotone association
 between physical-activity level and mean LDL cholesterol.

--- a/_subfiles/Linear-models-overview/_sec_linreg_ordinal.qmd
+++ b/_subfiles/Linear-models-overview/_sec_linreg_ordinal.qmd
@@ -9,26 +9,56 @@ We can create ordinal variables in R using the `ordered()` function^[or equivale
 
 :::{#exm-ordinal-variable}
 
-```{r}
-#| eval: false
-url <- paste0(
-  "https://regression.ucsf.edu/sites/g/files/tkssra6706/",
-  "f/wysiwyg/home/data/hersdata.dta"
-)
-library(haven)
-hers <- read_dta(url)
-```
+The `hers` data [@vittinghoff2e] is available in the `rmb` package:
 
 ```{r}
-#| include: false
 hers <- rmb::hers |> haven::zap_labels()
 ```
 
+::: {#tbl-hers-ordinal}
+
 ```{r}
-#| tbl-cap: "HERS dataset"
-#| label: tbl-HERS
+#| code-fold: true
 hers |> head()
 ```
+
+HERS data
+:::
+
+The `physact` variable records each participant's self-reported physical activity,
+relative to other women her age,
+on an ordered five-level scale
+(1 = much less active, …, 5 = much more active).
+We make it an ordered factor so that `lm()` uses polynomial contrasts,
+which respect the ordering,
+instead of the default treatment contrasts:
+
+```{r}
+hers <- hers |>
+  mutate(physact_ord = ordered(physact))
+
+lm_physact <- lm(LDL ~ physact_ord, data = hers)
+```
+
+::: {#tbl-hers-ordinal-fit}
+
+```{r}
+#| code-fold: true
+lm_physact |>
+  parameters::model_parameters() |>
+  parameters::print_md()
+```
+
+Mean LDL by physical-activity level, using polynomial contrasts
+:::
+
+With polynomial contrasts,
+each coefficient summarizes a trend component across the ordered levels:
+the linear term is the steady change in mean LDL per step up the scale,
+and the quadratic and higher terms capture curvature.
+Here the linear-trend coefficient is small and not statistically significant,
+so these data show little evidence of a monotone association
+between physical-activity level and mean LDL cholesterol.
 
 :::
 


### PR DESCRIPTION
## What

Phase-1 quick wins from the holistic HERS-usage audit in #960 — the low-risk, dataset-strategy-independent fixes. No change to the birthweight-vs-HERS running-example strategy (that's the larger decision tracked in #960).

## Changes

- **`_subfiles/Linear-models-overview/_sec_linreg_ordinal.qmd`**
  - Drop the hardcoded UCSF `read_dta("https://regression.ucsf.edu/.../hersdata.dta")` (shown to readers as the canonical load) and show the reproducible `rmb::hers |> haven::zap_labels()` load directly.
  - Rename the colliding `tbl-HERS` label → `tbl-hers-ordinal` (it collided with `chapters/HERS-example.qmd`), and use div syntax for the table.
  - Replace the `head()`-only stub with a **worked ordered-factor example**: `lm(LDL ~ ordered(physact))` using polynomial contrasts, with a short interpretation of the linear/quadratic trend coefficients.
- **`_subfiles/Linear-models-overview/_sec_linreg_diag_direct_viz.qmd`**
  - Lift the HERS study intro out of the `::: notes` block so the dataset is described in all output formats (handout/slides), not just speaker notes — HERS is first used here, so it should be introduced here.
- **`_subfiles/Linear-models-overview/_sec_linreg_model_selection.qmd`**
  - `olsrr:::ols_step_both_aic` → `olsrr::ols_step_both_aic` (the function is exported; this matches the file's existing `olsrr::ols_step_best_subset` usage).

## Verification

- `quarto render chapters/Linear-models-overview.qmd --to html` — clean (no broken `?@` cross-references; the new ordinal table renders).
- `lintr::lint()` on all three files — no new lints.
- `spelling::spell_check_package()` — no errors.

## Notes

- Subfiles were edited without their top-level chapter, so this PR carries the **`clear freezer`** label.
- The broader strategy (make HERS the running example vs. keep birthweight for first principles) and the larger standardization work remain tracked in #960; this PR is just the hygiene phase.

Refs #960.

---
_Generated by [Claude Code](https://claude.ai/code/session_015rRWEUteiN3Jc1WN622gwc)_