### PR TITLE
docs: note libglpk40 system dep for local renders (igraph/ggdag)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -800,7 +800,7 @@ Some R packages require system-level libraries to compile from source:
 - `png` package requires `libpng-dev`
 - `jpeg` package requires `libjpeg-dev`
 - `systemfonts` package requires `libfontconfig1-dev`
-- `igraph` (used by `ggdag` for DAG figures such as `fig-dag-heat-deaths`) requires `libglpk40` — install with `sudo apt-get install -y libglpk40`; without it a local `quarto render` halts with `Error in dyn.load(...): libglpk.so.40: cannot open shared object file`
+- `igraph` (used by `ggdag` for DAG figures such as `fig-dag-heat-deaths`) requires `libglpk40` (runtime dependency — needed even when installing pre-compiled binaries) — install with `sudo apt-get install -y libglpk40`; without it a local `quarto render` halts with `Error in dyn.load(...): libglpk.so.40: cannot open shared object file`
 - Consider using `rocker/verse` Docker image for workflows to reduce installation requirements
 
 ## JAGS Dependencies

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -800,6 +800,7 @@ Some R packages require system-level libraries to compile from source:
 - `png` package requires `libpng-dev`
 - `jpeg` package requires `libjpeg-dev`
 - `systemfonts` package requires `libfontconfig1-dev`
+- `igraph` (used by `ggdag` for DAG figures such as `fig-dag-heat-deaths`) requires `libglpk40` — install with `sudo apt-get install -y libglpk40`; without it a local `quarto render` halts with `Error in dyn.load(...): libglpk.so.40: cannot open shared object file`
 - Consider using `rocker/verse` Docker image for workflows to reduce installation requirements
 
 ## JAGS Dependencies


### PR DESCRIPTION
## What

While render-testing #963 locally, `quarto render chapters/Linear-models-overview.qmd` halted at the `fig-dag-heat-deaths` chunk with:

```
Error in dyn.load(...): libglpk.so.40: cannot open shared object file: No such file or directory
```

`ggdag`'s DAG figures pull in `igraph`, which links against GLPK. Installing `libglpk40` (`sudo apt-get install -y libglpk40`) fixes it.

Adds one bullet to the **System Dependencies** list in `.github/copilot-instructions.md` so the next person rendering rme locally doesn't have to rediscover it.

Docs-only; no code or content changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015rRWEUteiN3Jc1WN622gwc)_