### PR TITLE
fix(publish): give concept-map a distinct revealjs output-file

### DIFF
--- a/chapters/concept-map.qmd
+++ b/chapters/concept-map.qmd
@@ -1,5 +1,13 @@
 ---
 title: "Concept Map: Definitions and Results"
+format:
+  html: default
+  revealjs:
+    output-file: concept-map-slides.html
+  pdf:
+    output-file: concept-map-handout.pdf
+  docx:
+    output-file: concept-map-handout.docx
 ---
 
 {{< include shared-config.qmd >}}


### PR DESCRIPTION
Closes #966.

## Problem

The **Quarto Publish** workflow has failed on every `main` push since [#873](https://github.com/d-morrison/rme/pull/873) added `chapters/concept-map.qmd` — first failure was run #448; run #447 and earlier were green. The site has not redeployed since. The reported failure (https://github.com/d-morrison/rme/actions/runs/28466946584/job/84369063510, run #454 from [#963](https://github.com/d-morrison/rme/pull/963)) only inherited the already-broken `main`.

```
ERROR: NotFound: No such file or directory (os error 2):
  rename '.../chapters/concept-map.html' -> '.../_site/chapters/concept-map.html'
    at safeMoveSync (quarto.js)
    at renderProject (quarto.js)
```

## Root cause

`concept-map.qmd` was the **only** file in the `_quarto-website.yml` render list with **no `format:` block**, so it inherited all four project formats (`html`, `revealjs`, `pdf`, `docx`). The `revealjs` format's default output file is `concept-map.html` — the same path as the `html` page. Two formats wrote `chapters/concept-map.html`; Quarto's project move relocated it into `_site/` once, then failed relocating the same (now-gone) path a second time.

Every other appendix already avoids this by renaming its revealjs output (e.g. `package-versions.qmd` → `package-versions-slides.html`).

## Fix

Add a `format:` block to `concept-map.qmd` mirroring the sibling appendices, giving the revealjs/pdf/docx outputs distinct filenames:

```yaml
format:
  html: default
  revealjs:
    output-file: concept-map-slides.html
  pdf:
    output-file: concept-map-handout.pdf
  docx:
    output-file: concept-map-handout.docx
```

No chapter content or R code changed — front matter only.

## Verification

- A minimal, R-free `website` project with `format: {html, revealjs}` and a doc that omits the `output-file` rename reproduces the **exact** `safeMoveSync`/`renderProject` rename error; adding `revealjs: output-file: <name>-slides.html` makes the render succeed (produces both `<name>.html` and `<name>-slides.html`).
- Confirmed `concept-map.qmd` is the only render-list file lacking a `format:` block, so no sibling failure remains after this fix.
- A full local multi-format render of the book was not possible in this environment (the `renv` library and `tinytex` are not restored); the chapter's R chunks are unchanged and executed successfully in the failing CI runs — only the final project-move collision failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz1p3C4Ej5rqQh9U5utfLb)_