### PR TITLE
Harden new-chapter scaffolding against the revealjs/HTML output-file collision

### DIFF
--- a/.claude/commands/new-chapter.md
+++ b/.claude/commands/new-chapter.md
@@ -13,7 +13,23 @@ First, parse `$ARGUMENTS`: the first whitespace-delimited token is the **slug** 
 
 Steps:
 
-1. Create `chapters/<slug>.qmd` with YAML frontmatter holding just `title:` (set to the title). Do NOT set `date:` — the book sets `date: last-modified` globally, and a per-page `date:` would override it. Do NOT add a top-level `#` heading in the body — Quarto renders the frontmatter `title:` as the page heading.
+1. Create `chapters/<slug>.qmd` with YAML frontmatter containing the `title:` **and** a `format:` block that renames the `revealjs`, `pdf`, and `docx` outputs. The website profile renders every render-list page to all four project formats, and `revealjs` defaults its output to `<slug>.html` — the *same* path as the HTML page — which collides and breaks the publish workflow (see #966). Mirror the sibling appendices exactly:
+
+   ```yaml
+   ---
+   title: "<title>"
+   format:
+     html: default
+     revealjs:
+       output-file: <slug>-slides.html
+     pdf:
+       output-file: <slug>-handout.pdf
+     docx:
+       output-file: <slug>-handout.docx
+   ---
+   ```
+
+   Do NOT set `date:` — the book sets `date: last-modified` globally, and a per-page `date:` would override it. Do NOT add a top-level `#` heading in the body — Quarto renders the frontmatter `title:` as the page heading. If the page should be HTML-only (e.g. an interactive-diagram appendix), use `format:` with just `html: default` instead — that renders only HTML and cannot collide. Either way, `check-render-headers` CI enforces that every render-list page carries a collision-safe `format:` block.
 2. Register the chapter in the `book.chapters:` list in `_quarto-book.yml` at a logical position (read the file first). If it belongs to an existing `part:`, nest it under that part. **Also** add an entry to the appropriate navbar dropdown (`Chapters` or `Appendices`) in `_quarto-website.yml`, and ensure the file is in the `render:` list. The navbar is NOT auto-generated from `_quarto-book.yml` -- manual addition is required. Finally, add the page to the `render:` list in `_quarto-handout.yml` **if** it belongs in the handout PDF subset (omit supplemental or HTML-only pages such as interactive-diagram appendices).
 3. If the chapter is long, you may split content into includes under `chapters/_subfiles/<slug>/`. Subfiles must NOT start with a heading and must NOT contain a references section.
 4. Confirm it renders: `quarto render chapters/<slug>.qmd --to html`.

--- a/.github/scripts/check_render_list_headers.py
+++ b/.github/scripts/check_render_list_headers.py
@@ -1,27 +1,25 @@
 #!/usr/bin/env python3
-"""Guard the website render list against the revealjs/HTML output-file collision.
+"""Guard the website render list against output-file collisions.
 
 Every page in the ``render:`` list of ``_quarto-website.yml`` is rendered to the
-project's formats. The ``html`` format writes ``<stem>.html`` and the
-``revealjs`` format defaults its output to the *same* ``<stem>.html``. When a
-page is rendered to both without giving revealjs a distinct ``output-file``,
-Quarto's project move fails with
+project's formats. Each format writes an output file: ``html`` and ``revealjs``
+both default to ``<stem>.html``, ``pdf`` to ``<stem>.pdf``, ``docx`` to
+``<stem>.docx``. When two of a page's rendered formats resolve to the *same*
+output path, Quarto's project move fails with
 
     rename '.../<stem>.html' -> '_site/.../<stem>.html': No such file
 
 and the publish workflow dies (see issue #966 / PR #967). ``publish.yml`` only
-runs on push to ``main``, so a header-less page sails through PR CI and breaks
-the site after merge -- this check catches it on the PR instead.
+runs on push to ``main``, so a colliding page sails through PR CI and breaks the
+site after merge -- this check catches it on the PR instead.
 
-A render-list page is collision-safe when it does **not** render both ``html``
-and ``revealjs`` with a bare revealjs output. Concretely, a page is flagged when:
+The classic trigger is a page with no ``format:`` block: it inherits the project
+formats (which pair ``html`` with a bare ``revealjs``, both writing
+``<stem>.html``). But any page whose rendered formats resolve two identical
+output paths is flagged -- e.g. a hand-edited header that sets
+``revealjs: output-file: <stem>.html``, reusing the html default.
 
-* it declares no ``format:`` block -- it inherits the project formats (which
-  include both ``html`` and ``revealjs``), so revealjs collides; or
-* its effective formats include both ``html`` and ``revealjs`` and that
-  revealjs entry carries no ``output-file``.
-
-Exit status is 1 (with a per-file report) if any page is unsafe, 0 otherwise.
+Exit status is 1 (with a per-file report) if any page collides, 0 otherwise.
 """
 
 from __future__ import annotations
@@ -32,6 +30,18 @@ from pathlib import Path
 import yaml
 
 WEBSITE_CONFIG = "_quarto-website.yml"
+
+# Default output extension per Quarto format. revealjs shares html's `.html`,
+# which is the collision at the heart of #966. Formats not listed fall back to
+# the format name, which cannot spuriously collide with these.
+DEFAULT_EXT = {
+    "html": "html",
+    "revealjs": "html",
+    "pdf": "pdf",
+    "docx": "docx",
+    "gfm": "md",
+    "ipynb": "ipynb",
+}
 
 
 def load_yaml(path: Path) -> dict:
@@ -61,36 +71,48 @@ def format_keys(format_block) -> list[str]:
     return []
 
 
-def revealjs_has_output_file(format_block) -> bool:
-    """True when the `revealjs` entry in a format block sets `output-file`."""
-    if not isinstance(format_block, dict):
-        return False
-    revealjs = format_block.get("revealjs")
-    return isinstance(revealjs, dict) and "output-file" in revealjs
+def format_output_file(stem: str, fmt: str, doc_format, project_format) -> str:
+    """Resolve the output filename a format writes for a page.
+
+    A document-level `output-file` wins over a project-level one; absent both,
+    the format writes `<stem>.<default-ext>`.
+    """
+    for source in (doc_format, project_format):
+        if isinstance(source, dict):
+            entry = source.get(fmt)
+            if isinstance(entry, dict) and entry.get("output-file"):
+                return str(entry["output-file"])
+    return f"{stem}.{DEFAULT_EXT.get(fmt, fmt)}"
 
 
 def collision_reason(qmd_path: Path, project_format) -> str | None:
-    """Return why a render-list page would collide, or None if it is safe."""
+    """Return why a render-list page's outputs collide, or None if it is safe."""
     doc_format = front_matter(qmd_path).get("format")
 
-    # No document-level `format:` block -> the page inherits the project
-    # formats, which pair html with a bare revealjs.
-    if doc_format is None:
-        if {"html", "revealjs"} <= set(format_keys(project_format)):
-            return "no `format:` block, so it inherits the project's html+revealjs (revealjs writes <stem>.html)"
+    # A document-level `format:` block restricts the page to exactly those
+    # formats; without one, the page inherits the project's formats.
+    rendered = format_keys(doc_format if doc_format is not None else project_format)
+    stem = qmd_path.stem
+
+    outputs: dict[str, list[str]] = {}
+    for fmt in rendered:
+        out = format_output_file(stem, fmt, doc_format, project_format)
+        outputs.setdefault(out, []).append(fmt)
+
+    collisions = {out: fmts for out, fmts in outputs.items() if len(fmts) > 1}
+    if not collisions:
         return None
 
-    # Document declares its own formats -> it renders exactly those.
-    keys = set(format_keys(doc_format))
-    if {"html", "revealjs"} <= keys and not revealjs_has_output_file(doc_format):
-        return "renders both html and revealjs but revealjs has no `output-file`"
-    return None
+    inherited = "" if doc_format is not None else " (no `format:` block; inherits project formats)"
+    detail = "; ".join(
+        f"{out} <- {', '.join(sorted(fmts))}" for out, fmts in sorted(collisions.items())
+    )
+    return f"formats write the same output file{inherited}: {detail}"
 
 
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[2]
-    config_path = repo_root / WEBSITE_CONFIG
-    config = load_yaml(config_path)
+    config = load_yaml(repo_root / WEBSITE_CONFIG)
 
     project_format = config.get("format", {})
     render_list = config.get("project", {}).get("render", []) or []
@@ -107,18 +129,18 @@ def main() -> int:
             offenders.append((entry, reason))
 
     if offenders:
-        print("Render-list pages with an unsafe (colliding) format header:\n")
+        print("Render-list pages whose rendered formats collide on an output file:\n")
         for entry, reason in offenders:
             print(f"  - {entry}: {reason}")
         print(
-            "\nGive each flagged page a `format:` block whose `revealjs` entry sets a "
-            "distinct `output-file` (e.g. `<slug>-slides.html`), mirroring the sibling "
-            "appendices, or restrict it to `format: {html: default}` if it is HTML-only. "
-            "See issue #966 / PR #967."
+            "\nGive each rendered format a distinct output path -- typically a `format:` "
+            "block whose `revealjs` entry sets `output-file: <slug>-slides.html` "
+            "(mirroring the sibling appendices), or restrict the page to "
+            "`format: {html: default}` if it is HTML-only. See issue #966 / PR #967."
         )
         return 1
 
-    print(f"OK: all {len(qmd_entries)} website render-list pages have collision-safe format headers.")
+    print(f"OK: all {len(qmd_entries)} website render-list pages resolve distinct output files per format.")
     return 0
 
 

--- a/.github/scripts/check_render_list_headers.py
+++ b/.github/scripts/check_render_list_headers.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Guard the website render list against the revealjs/HTML output-file collision.
+
+Every page in the ``render:`` list of ``_quarto-website.yml`` is rendered to the
+project's formats. The ``html`` format writes ``<stem>.html`` and the
+``revealjs`` format defaults its output to the *same* ``<stem>.html``. When a
+page is rendered to both without giving revealjs a distinct ``output-file``,
+Quarto's project move fails with
+
+    rename '.../<stem>.html' -> '_site/.../<stem>.html': No such file
+
+and the publish workflow dies (see issue #966 / PR #967). ``publish.yml`` only
+runs on push to ``main``, so a header-less page sails through PR CI and breaks
+the site after merge -- this check catches it on the PR instead.
+
+A render-list page is collision-safe when it does **not** render both ``html``
+and ``revealjs`` with a bare revealjs output. Concretely, a page is flagged when:
+
+* it declares no ``format:`` block -- it inherits the project formats (which
+  include both ``html`` and ``revealjs``), so revealjs collides; or
+* its effective formats include both ``html`` and ``revealjs`` and that
+  revealjs entry carries no ``output-file``.
+
+Exit status is 1 (with a per-file report) if any page is unsafe, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+WEBSITE_CONFIG = "_quarto-website.yml"
+
+
+def load_yaml(path: Path) -> dict:
+    """Parse a YAML file into a dict (empty dict if it holds no mapping)."""
+    with path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    return data or {}
+
+
+def front_matter(qmd_path: Path) -> dict:
+    """Return a .qmd file's YAML front matter as a dict (empty if none)."""
+    text = qmd_path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    return yaml.safe_load(parts[1]) or {}
+
+
+def format_keys(format_block) -> list[str]:
+    """Return the format names declared in a `format:` block."""
+    if isinstance(format_block, dict):
+        return list(format_block.keys())
+    if isinstance(format_block, str):
+        return [format_block]
+    return []
+
+
+def revealjs_has_output_file(format_block) -> bool:
+    """True when the `revealjs` entry in a format block sets `output-file`."""
+    if not isinstance(format_block, dict):
+        return False
+    revealjs = format_block.get("revealjs")
+    return isinstance(revealjs, dict) and "output-file" in revealjs
+
+
+def collision_reason(qmd_path: Path, project_format) -> str | None:
+    """Return why a render-list page would collide, or None if it is safe."""
+    doc_format = front_matter(qmd_path).get("format")
+
+    # No document-level `format:` block -> the page inherits the project
+    # formats, which pair html with a bare revealjs.
+    if doc_format is None:
+        if {"html", "revealjs"} <= set(format_keys(project_format)):
+            return "no `format:` block, so it inherits the project's html+revealjs (revealjs writes <stem>.html)"
+        return None
+
+    # Document declares its own formats -> it renders exactly those.
+    keys = set(format_keys(doc_format))
+    if {"html", "revealjs"} <= keys and not revealjs_has_output_file(doc_format):
+        return "renders both html and revealjs but revealjs has no `output-file`"
+    return None
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    config_path = repo_root / WEBSITE_CONFIG
+    config = load_yaml(config_path)
+
+    project_format = config.get("format", {})
+    render_list = config.get("project", {}).get("render", []) or []
+    qmd_entries = [entry for entry in render_list if str(entry).endswith(".qmd")]
+
+    offenders: list[tuple[str, str]] = []
+    for entry in qmd_entries:
+        qmd_path = repo_root / entry
+        if not qmd_path.exists():
+            offenders.append((entry, "listed in render: but the file does not exist"))
+            continue
+        reason = collision_reason(qmd_path, project_format)
+        if reason is not None:
+            offenders.append((entry, reason))
+
+    if offenders:
+        print("Render-list pages with an unsafe (colliding) format header:\n")
+        for entry, reason in offenders:
+            print(f"  - {entry}: {reason}")
+        print(
+            "\nGive each flagged page a `format:` block whose `revealjs` entry sets a "
+            "distinct `output-file` (e.g. `<slug>-slides.html`), mirroring the sibling "
+            "appendices, or restrict it to `format: {html: default}` if it is HTML-only. "
+            "See issue #966 / PR #967."
+        )
+        return 1
+
+    print(f"OK: all {len(qmd_entries)} website render-list pages have collision-safe format headers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-render-headers.yaml
+++ b/.github/workflows/check-render-headers.yaml
@@ -1,0 +1,36 @@
+---
+name: check-render-headers
+
+# Fails when a page in the `_quarto-website.yml` render list would render both
+# `html` and `revealjs` to the same `<stem>.html` output -- the collision that
+# broke the publish workflow in #966 / #967. `publish.yml` only runs on push to
+# `main`, so this cheap static check is what catches the bug on the PR instead.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  check-render-headers:
+    runs-on: ubuntu-latest
+    name: check-render-headers
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Check render-list pages have collision-safe format headers
+        run: python .github/scripts/check_render_list_headers.py


### PR DESCRIPTION
Closes #969. Follow-up to #966 / #967.

Two small, complementary infra changes so the "render-list page with no collision-safe `format:` block" bug — which broke the publish workflow for two days — can't come back. No book content.

## (a) Fix the scaffolder — prevention

`.claude/commands/new-chapter.md` step 1 told the scaffolder to create pages "with YAML frontmatter holding **just `title:`**", then step 2 wired them into the website `render:` list — planting exactly the [#966](https://github.com/d-morrison/rme/issues/966) collision. Step 1 now emits the standard sibling-appendix header:

```yaml
---
title: "<title>"
format:
  html: default
  revealjs:
    output-file: <slug>-slides.html
  pdf:
    output-file: <slug>-handout.pdf
  docx:
    output-file: <slug>-handout.docx
---
```

with a note about the HTML-only escape hatch (`format: {html: default}`).

## (b) Add a CI guard — enforcement

A skill only helps when it's invoked, and `publish.yml` runs only on push to `main`, so a header-less page (like `concept-map.qmd`) reaches `main` unflagged by PR CI. New `check-render-headers` workflow + `.github/scripts/check_render_list_headers.py`: a fast, pure-Python + PyYAML static check that fails a PR when any page in the `_quarto-website.yml` render list would render both `html` and `revealjs` with a bare revealjs output (the `<stem>.html` collision). Runs in seconds, independent of how the file was created.

**A page is flagged when:**
- it declares no `format:` block (inherits the project's html+revealjs, so revealjs collides), or
- its effective formats include both `html` and `revealjs` and the revealjs entry has no `output-file`.

## Verification

- `check_render_list_headers.py` **passes** on the current tree (all 37 render-list pages).
- **Negative test:** temporarily stripping `concept-map.qmd` down to a title-only header makes the check exit 1 with a clear per-file message — confirming it would have caught #873 pre-merge.
- Workflow and script YAML/parse validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz1p3C4Ej5rqQh9U5utfLb)_