### PR TITLE
Wire in check-equation-renders to catch broken MathJax equations

### DIFF
--- a/.github/workflows/check-equation-renders.yml
+++ b/.github/workflows/check-equation-renders.yml
@@ -1,0 +1,22 @@
+# Fourth leg of the PR-preview family, delegated to the reusable workflow in
+# d-morrison/gha. Triggered when the build workflow finishes, it downloads the
+# build artifact and crawls it with a headless browser to catch equations
+# MathJax can't render -- invisible in the Quarto/pandoc build log, since
+# MathJax only typesets client-side (see d-morrison/rme#972).
+#
+# NOTE: the `workflows:` value below MUST match the `name:` of the build
+# workflow (preview.yml). `workflow_run` triggers only fire when this file
+# lives on the default branch.
+name: Quarto Check Equation Renders
+
+on:
+  workflow_run:
+    workflows: ["Quarto Preview Build"]
+    types: [completed]
+
+jobs:
+  check:
+    permissions:
+      contents: read
+      actions: read  # needed to download the build artifact
+    uses: d-morrison/gha/.github/workflows/check-equation-renders.yml@v2


### PR DESCRIPTION
## Summary

Closes #972.

**Draft — depends on [d-morrison/gha#160](https://github.com/d-morrison/gha/pull/160) merging and its `@v2` tag
moving forward to include the new workflow.** Until then, this workflow's `uses:` target doesn't exist yet and the
job will fail with a workflow-not-found error.

[#954](https://github.com/d-morrison/rme/pull/954) shipped a PR preview with a broken equation that nothing in the
PR-preview pipeline caught. Quarto/pandoc (`html-math-method: mathjax`) embed raw TeX unchanged in the static HTML;
MathJax only parses and typesets it **client-side**, in the browser, so a bad equation (plausibly an undefined
custom macro, since this book leans on `latex-macros/`) produces no warning in the Quarto/pandoc build log.

`gha#160` adds `check-equation-renders`: a fourth leg of the PR-preview family that triggers on the same
`workflow_run` completion as `preview-deploy.yml`, downloads the `pr-preview-site` artifact, and crawls it with a
headless browser to catch this.

This PR adds the caller stub, `.github/workflows/check-equation-renders.yml`, matching the existing `preview.yml` /
`preview-deploy.yml` stubs.

## Test plan

- [ ] `gha#160` merges and `@v2` moves forward to include `check-equation-renders.yml`
- [ ] Mark this PR ready for review
- [ ] Open a PR here with a deliberately broken equation (or re-push #954's original stub) to confirm the new check
      actually fires and fails


---
_Generated by [Claude Code](https://claude.ai/code/session_01YKbhz4xQpRXdheHifCjKyE)_