### PR TITLE
Opt into claude-code-review.yml's check-latex-macros input

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,6 +44,11 @@ jobs:
       # can read macros the chapters reference instead of reporting them as
       # "not initialized" (see PR #806).
       checkout-submodules: true
+      # Flag PR-diff LaTeX simplifiable via an existing latex-macros/macros.qmd
+      # macro, and nontrivial expressions repeated 3+ times that are
+      # candidates for a new one. Needs checkout-submodules: true (above) to
+      # find real macro definitions — the reviewer has no network-fetch tools.
+      check-latex-macros: true
       # Same CAS tooling copilot-setup-steps.yml and claude.yml install, so the
       # reviewer's Bash tool can symbolically check a derivation it's reviewing
       # instead of eyeballing the algebra.


### PR DESCRIPTION
Closes #979.

## Summary

- Adds `check-latex-macros: true` to `.github/workflows/claude-code-review.yml`'s
  `with:` block, alongside the existing `checkout-submodules: true`.
- `d-morrison/gha#204` (merged, live at `@v2`) added this opt-in input: the
  reviewer now also flags PR-diff LaTeX simplifiable via an existing
  `latex-macros/macros.qmd` macro, and nontrivial expressions repeated 3+
  times that are candidates for a new one.
- This repo already sets `checkout-submodules: true` for the same
  `latex-macros` submodule (the new input's only prerequisite — the reviewer
  has no network-fetch tools, so it can only read macro definitions from a
  locally checked-out submodule), and `CLAUDE.md`'s "Math Notation" section
  already says to use `latex-macros/macros.qmd` macros instead of raw LaTeX,
  so this is a natural fit.

## Verification

CI on this PR itself is the live-fire test: the review that runs on this
diff should demonstrate the new checks are wired correctly (though this
diff has no LaTeX math to flag). A genuine positive-case test (a PR
deliberately duplicating an existing macro) is a good follow-up once this
lands, to confirm the reviewer actually catches it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NctuW5wKEKgcj33cH5UJ8c)_