### PR TITLE
Slide latex-macros submodule to 8ce5d0c (#78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ Before committing any `.qmd`, `.R`, or config file change:
   - Use the generic `\ratio`/`\ratiof` macro when a ratio's inputs are the **quantities themselves** (the odds, hazards, rates, etc.) — e.g. `\ratio(\odds_1, \odds_2)`, **not** `\ror(\odds_1, \odds_2)` — because the type of ratio is clear from the inputs.
   - Use the type-subscripted ratio macros (`\ror` for odds ratios, `\hazratio`/`\hr` for hazard ratios, `\rateratio`, `\riskratio`, `\prevratio`, `\cuhazratio`, …) only when the inputs are **covariate patterns** (e.g. `\ror(\vx,\vxs)`, `\hr(t\mid\vx:\vxs)`), where the subscript is needed to say which kind of ratio it is.
   - Factors compare **one** covariate pattern to the implicit baseline pattern (e.g. the Cox risk score `\hazfactor(\vx)`); always use the subscripted factor macros (`\hazfactor`, `\oddsfactor`, …; function forms `\hazfactorf`/`\hazff`, …).
+- **Estimator indirection (`\est`/`\Est`), added in `latex-macros` #78:** every
+  legacy `\h...`-prefixed hat-estimator macro (`\hb`, `\hsurv`, `\hhazratio`,
+  `\hskm`, …) now has a parallel `\e...`-prefixed counterpart (`\eb`, `\esurv`,
+  `\ehazratio`, `\eskm`, …) composed through the new `\est` (renders `\hat`) /
+  `\Est` (renders `\widehat`) indirection macros, instead of applying
+  `\hat`/`\widehat` directly. Prefer the `\e...` family in new content — a
+  future change to the estimator symbol only requires editing `\est`/`\Est`.
+  The `\h...` family is unchanged and stays supported for existing content.
+  See `latex-macros/CONTRIBUTING.md` for the full naming convention.
 
 ### Citations
 - Always use BibTeX keys with `@citekey` Pandoc syntax — never plaintext author-date


### PR DESCRIPTION
## Summary
- Bumps the `latex-macros` submodule pin from `27d9d11` to `8ce5d0c` (one new upstream commit: [d-morrison/macros#78](https://github.com/d-morrison/macros/pull/78))
- Documents the new macros in `CLAUDE.md`'s Math Notation section

## What's new upstream
`macros` #78 adds a parallel `\e...`-prefixed estimator macro family
(`\eb`, `\esurv`, `\ehazratio`, `\eskm`, …) alongside every existing
`\h...`-prefixed hat-estimator macro, composed through new `\est` (`\hat`)
/ `\Est` (`\widehat`) indirection macros instead of applying `\hat`/`\widehat`
directly. No existing macro was renamed or removed.

## Test plan
- [x] `git submodule status` confirms `latex-macros` now resolves to `8ce5d0c`
- [x] No `.qmd` content changed — this is a pin bump plus a doc note, not a rendering change


---
_Generated by [Claude Code](https://claude.ai/code/session_013oWL7T1ysQpp16kbZhAsPr)_