### PR TITLE
CLAUDE.md: point derivation-steps rule at ai-config shared fragment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,13 @@ Before committing any `.qmd`, `.R`, or config file change:
 ### Math Notation
 - Use custom macros from `latex-macros/macros.qmd` instead of raw LaTeX
 - Key macros: `\E{Y|X=x}`, `\ba`/`\ea`, `\tp{v}`, `\b`, `\g`, `\a`, `\devn(...)`, `\erf{...}`
-- Include every intermediate step in derivations — do not skip steps
+- Include every intermediate step in derivations — do not skip steps. This is
+  a global standing rule from `d-morrison/ai-config`'s
+  `shared/writing/math-derivation-steps.md`, which also covers the
+  review-side counterpart: a reviewer (including the `@claude` bot, via
+  `d-morrison/gha`'s review checklist) should name the exact gap and the
+  missing operation when a step is skipped, not just flag "skipped steps" in
+  general.
 - Color coding: `\red{...}` for focal/extra terms, `\blue{...}` for shared terms
 - **Matrix dimensions**: always verify dimension compatibility for every matrix expression -- dimensions of each operand must be consistent with the operation
 - **Annotate matrix dimensions with underbraces** in display math: use `\underbrace{M}_{m \times n}` for each matrix or vector

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,14 @@ Before committing any `.qmd`, `.R`, or config file change:
 - Key macros: `\E{Y|X=x}`, `\ba`/`\ea`, `\tp{v}`, `\b`, `\g`, `\a`, `\devn(...)`, `\erf{...}`
 - Include every intermediate step in derivations — do not skip steps. This is
   a global standing rule from `d-morrison/ai-config`'s
-  `shared/writing/math-derivation-steps.md`, which also covers the
-  review-side counterpart: a reviewer (including the `@claude` bot, via
-  `d-morrison/gha`'s review checklist) should name the exact gap and the
-  missing operation when a step is skipped, not just flag "skipped steps" in
-  general.
+  `shared/writing/math-derivation-steps.md` (submodule pin bumped in this PR
+  to a commit that includes it), which also covers the review-side
+  counterpart: a reviewer should name the exact gap and the missing
+  operation when a step is skipped, not just flag "skipped steps" in
+  general. The `@claude` bot will apply this automatically via
+  `d-morrison/gha`'s review checklist once
+  [gha#228](https://github.com/d-morrison/gha/pull/228) merges and the
+  `@v2` tag it pins picks up the change.
 - Color coding: `\red{...}` for focal/extra terms, `\blue{...}` for shared terms
 - **Matrix dimensions**: always verify dimension compatibility for every matrix expression -- dimensions of each operand must be consistent with the operation
 - **Annotate matrix dimensions with underbraces** in display math: use `\underbrace{M}_{m \times n}` for each matrix or vector


### PR DESCRIPTION
## Summary

- Updates the "Math Notation" section's "don't skip steps" bullet to cite
  `d-morrison/ai-config`'s new `shared/writing/math-derivation-steps.md`
  ([ai-config#502](https://github.com/d-morrison/ai-config/pull/502)) as the
  canonical source, instead of carrying an independent copy of just the
  writing-time half of the rule.
- Notes the review-side counterpart: when a step is skipped, a reviewer
  (including the `@claude` bot, via `d-morrison/gha`'s review checklist —
  [gha#228](https://github.com/d-morrison/gha/pull/228)) should name the exact
  gap and the missing operation, not just flag "skipped steps" in general.

No behavior change to rme's own writing rule — this only consolidates the
duplicated prose and adds the review-side pointer.

## Test plan

- [x] Confirmed rme's `claude.yml`/`claude-code-review.yml` pin
      `d-morrison/gha`'s reusable workflows, so the new gha review-guideline
      item (#228) will actually apply here once merged.
- [ ] Companion PRs `d-morrison/ai-config#502` and `d-morrison/gha#228` merge
      (this PR doesn't depend on them functionally, since it just adds a
      citation, but they're the source of truth being cited).


---
_Generated by [Claude Code](https://claude.ai/code/session_012Nqwqg3LwoVaAjbcxpMQEo)_