### PR TITLE
Add .gitattributes with union merge for references.bib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Auto-detect text files and normalize them to LF in the working tree on
+# checkout, regardless of each contributor's global git config.
+* text=auto eol=lf
+
+# Shell scripts must use LF line endings — a CRLF on the shebang line makes
+# the kernel look for "/bin/bash\r" and fail with "bad interpreter".
+*.sh text eol=lf
+
+# Files where conflicting edits from both branches should typically both be
+# kept rather than forcing a manual conflict resolution.
+references.bib merge=union
+CLAUDE.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,14 @@
 # the kernel look for "/bin/bash\r" and fail with "bad interpreter".
 *.sh text eol=lf
 
-# Files where conflicting edits from both branches should typically both be
-# kept rather than forcing a manual conflict resolution.
+# references.bib entries are independent, uniquely-keyed blocks, so two
+# branches adding distinct entries can usually be combined automatically
+# instead of forcing a manual conflict resolution. This only helps when git
+# itself performs the merge (a local merge/rebase, or CI) — GitHub's own
+# web-merge button and mergeability check don't apply custom merge drivers.
+# CLAUDE.md is deliberately NOT included here: unlike bib entries, its prose
+# is actively reworded in place, and a union merge of two differing edits to
+# the same rule silently keeps both versions with no conflict raised
+# (confirmed by a local merge simulation) — unacceptable for a file whose
+# instructions are meant to be followed exactly.
 references.bib merge=union
-CLAUDE.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,9 +11,16 @@
 # instead of forcing a manual conflict resolution. This only helps when git
 # itself performs the merge (a local merge/rebase, or CI) — GitHub's own
 # web-merge button and mergeability check don't apply custom merge drivers.
+# Known risk (confirmed by local merge simulation): when both branches'
+# insertions land at the same point in the file, git's union driver can
+# silently drop a line where the two inserted blocks share identical
+# boilerplate (e.g. the closing "}" every BibTeX entry ends with),
+# producing a malformed .bib with mismatched braces and no conflict
+# raised. A Quarto render / bibliography-check CI job is the backstop that
+# catches this before it reaches main — skim the merged file regardless.
 # CLAUDE.md is deliberately NOT included here: unlike bib entries, its prose
 # is actively reworded in place, and a union merge of two differing edits to
-# the same rule silently keeps both versions with no conflict raised
-# (confirmed by a local merge simulation) — unacceptable for a file whose
+# the same rule silently keeps both versions with no conflict raised, with
+# no automated check to catch it — unacceptable for a file whose
 # instructions are meant to be followed exactly.
 references.bib merge=union

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,6 +33,7 @@ on:
       - '_subfiles/**'
       - '*.scss'
       - 'latex-macros'
+      - 'references.bib'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add a `.gitattributes` file (none existed before) with the standard `* text=auto eol=lf` / `*.sh text eol=lf` line-ending boilerplate used in sibling repos
- Mark `references.bib` with `merge=union`, so conflicting edits from both branches (e.g. two PRs each adding a bibliography entry) are combined automatically instead of requiring manual conflict resolution
- `CLAUDE.md merge=union` was tried but dropped: a local merge simulation confirmed that unlike `references.bib`'s independent, uniquely-keyed entries, `CLAUDE.md`'s prose is reworded in place, so a union merge of two branches editing the same rule differently silently keeps both contradictory versions with no conflict raised — unacceptable for a file whose instructions are meant to be followed exactly
- **Correction:** `references.bib` is not risk-free either. A follow-up merge simulation found that when two branches each insert a distinct entry at the same point in the file, git's union driver can silently drop the shared closing `}` boundary line, producing malformed BibTeX with no conflict raised
- **Second correction:** the `.gitattributes` comment originally claimed a Quarto render CI job would catch that corruption before merge — review caught that `preview.yml`'s path filter excluded `references.bib` entirely, so that backstop didn't actually exist. Added `references.bib` to `preview.yml`'s `paths:` filter so the claim is now true

## Test plan
- [x] Confirmed via a local merge simulation that two branches each rewording the same `CLAUDE.md` line differently silently produce duplicated/contradictory content under `merge=union` — this is why `CLAUDE.md` was excluded
- [x] Confirmed via a local merge simulation that `references.bib` *does* share a failure mode with `CLAUDE.md`: two branches each inserting a distinct entry at the same point in the file can silently drop a shared boundary line (e.g. the closing `}`), producing malformed BibTeX
- [x] Confirmed `preview.yml` now includes `references.bib` in its trigger paths, so a bib-only PR gets a pre-merge render that would surface the resulting invalid `.bib`
