### PR TITLE
Pin DESCRIPTION Remotes to fixed commits, not bare owner/repo

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -12,6 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # renv::restore() only needs each package's already-pinned RemoteSha from
+      # renv.lock; it doesn't need to also re-resolve DESCRIPTION's Remotes:
+      # field against GitHub's API (a source of flaky/rate-limited failures --
+      # see d-morrison/rme#994). Disabling this consistency check removes that
+      # extra network dependency without changing which package versions get
+      # installed.
+      RENV_CONFIG_INSTALL_REMOTES: false
     steps:
       - uses: actions/checkout@v7
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,7 +80,7 @@ Depends:
     R (>= 4.1)
 LazyData: true
 Remotes:
-    ddsjoberg/gtsummary,
-    insightsengineering/cardx,
-    insightsengineering/cards,
-    d-morrison/rmb
+    ddsjoberg/gtsummary@952b6653103a9c485fe2abe9d16a6e2a7b68c80b,
+    insightsengineering/cardx@7c07c87fac43332ee24fa48b9c8c029ac2a417c6,
+    insightsengineering/cards@a7c447f9e8d0f44375ec4d5f8af03ba31d7147a1,
+    d-morrison/rmb@1d9c218920b2e5e4fe42539d5c9cfe33eac91217


### PR DESCRIPTION
Closes #994

`DESCRIPTION`'s `Remotes:` field listed all four GitHub dependencies (`gtsummary`, `cardx`, `cards`, `rmb`) as bare `owner/repo`, with no pinned ref, and `.github/workflows/lint-changed-files.yaml` called `renv::restore()` without disabling renv's DESCRIPTION-Remotes consistency check. Both let `renv::restore()`'s dependency-graph step re-resolve each remote against a live GitHub API call on every CI run, instead of using the commit already locked in `renv.lock`. That's what's been failing repeatedly in CI on #992:

```
Error: failed to resolve remote 'insightsengineering/cardx' -- error downloading
'https://api.github.com/repos/insightsengineering/cardx/contents/DESCRIPTION?ref=<sha>' [error code 22]
```

**Fix, in two parts:**

1. **Pin each remote to the exact commit already recorded in `renv.lock`'s `RemoteSha`** (`owner/repo@sha` syntax):

   | Package | Pinned SHA (from `renv.lock`) |
   |---|---|
   | `ddsjoberg/gtsummary` | `952b6653103a9c485fe2abe9d16a6e2a7b68c80b` |
   | `insightsengineering/cardx` | `7c07c87fac43332ee24fa48b9c8c029ac2a417c6` |
   | `insightsengineering/cards` | `a7c447f9e8d0f44375ec4d5f8af03ba31d7147a1` |
   | `d-morrison/rmb` | `1d9c218920b2e5e4fe42539d5c9cfe33eac91217` |

   This alone turned out to be **insufficient** — it just moves the same live-API dependency to a different renv code path (`renv_remotes_resolve_github_sha_ref`, hitting `/commits/<sha>` instead of `/contents/DESCRIPTION?ref=<sha>`), which fails identically. Kept anyway as good practice (documents exactly what's locked).

2. **The actual fix:** set `RENV_CONFIG_INSTALL_REMOTES: false` on the `lint-changed-files` job. `renv::restore()` doesn't need `DESCRIPTION`'s `Remotes:` field at all — every package's remote metadata (`RemoteType`/`RemoteHost`/`RemoteRepo`/`RemoteSha`) is already recorded directly in `renv.lock`. The `Remotes:` field is only consulted because renv's `install.remotes` config option defaults to `TRUE` (for `renv::install()`/`snapshot()` workflows adding a *new* dependency); disabling it for this job skips that consistency check entirely, removing the flaky network dependency without changing which package versions actually get restored.

**Verification:** confirmed the failure reproduced identically across 6 consecutive CI runs on #992/#995 (all four candidate remotes are equally exposed — `gtsummary` hit the same error independently during local environment setup for this session too). Confirmed `insightsengineering/cardx` is a real, active, public repo (not moved/deleted) via web search, ruling out a 404. Could not reproduce or test either fix locally in this sandboxed session (outbound GitHub API access here is scoped/blocked for repos outside the session — a different failure mode than the real CI runner's), so this PR is verified by watching whether `lint-changed-files` goes green on this PR after the second commit.

**Known remaining gap:** the `build / build` check delegates to `d-morrison/gha`'s shared `preview` composite action, which has the identical unguarded `setup-renv` call. Fixing that requires a companion change in `d-morrison/gha` (a shared, multi-consumer action) — out of scope for this repo-local PR; tracking separately.

This PR is metadata + workflow-YAML only — no `.qmd`/`.R`/lockfile/content touched.