### PR TITLE
Fix stale gha#228 forward-reference in CLAUDE.md's derivation-steps rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,12 @@ Before committing any `.qmd`, `.R`, or config file change:
   or approximation it uses (e.g. a trailing `&& \text{(...)}` column in an
   aligned block, as in `@eq-ph-surv-discretized`). Default to this level of
   explicitness for all derivations. This is a global standing rule from
-  `d-morrison/ai-config`'s `shared/writing/math-derivation-steps.md`
-  (submodule pin bumped in this PR to a commit that includes it), which
+  `d-morrison/ai-config`'s `shared/writing/math-derivation-steps.md`, which
   also covers the review-side counterpart: a reviewer should name the
   exact gap and the missing operation when a step is skipped, not just
-  flag "skipped steps" in general. The `@claude` bot will apply this
-  automatically via `d-morrison/gha`'s review checklist once
-  [gha#228](https://github.com/d-morrison/gha/pull/228) merges and the
-  `@v2` tag it pins picks up the change.
+  flag "skipped steps" in general. The `@claude` bot applies this
+  automatically via `d-morrison/gha`'s review checklist
+  ([gha#228](https://github.com/d-morrison/gha/pull/228)).
 - **Matrix dimensions**: always verify dimension compatibility for every matrix expression -- dimensions of each operand must be consistent with the operation
 - **Annotate matrix dimensions with underbraces** in display math: use `\underbrace{M}_{m \times n}` for each matrix or vector
 - **Zero matrices**: never write bare `\mathbf{0}` in a matrix equation -- subscript dimensions: `\mathbf{0}_{m \times n}`


### PR DESCRIPTION
Closes #1015.

## Summary

`CLAUDE.md`'s "Include every intermediate step in derivations" bullet ended with a forward-looking hedge — "once [gha#228](https://github.com/d-morrison/gha/pull/228) merges and the `@v2` tag ... picks up the change." Both conditions are now satisfied:

- gha#228 merged 2026-07-05.
- gha's `@v2` tag was manually slid past that merge on 2026-07-06 (gha stopped auto-sliding per [gha#225](https://github.com/d-morrison/gha/pull/225), so it needed an explicit `workflow_dispatch`).

Rewrote the sentence as present-tense fact, and dropped the "(submodule pin bumped in this PR to a commit that includes it)" aside — that phrasing only made sense while the PR that added it (#772) was still open. Verified separately (`git merge-base --is-ancestor`) that the current `.ai-config` submodule pin already includes `ai-config#502`'s `shared/writing/math-derivation-steps.md` fragment, so the parenthetical is just dropped rather than reworded.

## Test plan

- [x] Read the updated paragraph in context — reads coherently, no dangling references.
- Not a `.qmd`/`.R`/code change, so the render/lint/spellcheck checklist doesn't apply; this is a plain `CLAUDE.md` prose fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UetL8Q8Mff8snHyfPL2DSV)_