### PR TITLE
Fix concrete bugs in logistic-regression chapter

### DIFF
--- a/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
+++ b/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
@@ -60,7 +60,7 @@ $$
 \deriv{a}\eta(P=0, A = a) 
 &= \deriv{a} (\beta_0 + \beta_P 0 + \beta_A a + \beta_{PA}(0\cdot a))
 \\
-&= \deriv{a}\beta_0 + \deriv{a}\beta_P 0 + \deriv{a}\beta_A a + \deriv{a}\beta_{PA}(0\cdot a))
+&= \deriv{a}\beta_0 + \deriv{a}\beta_P 0 + \deriv{a}\beta_A a + \deriv{a}\beta_{PA}(0\cdot a)
 \\
 &=  0 + 0 + \beta_A + 0
 \\
@@ -85,7 +85,7 @@ $$
 
 That is,
 $\beta_{A}$ is the difference in 
-log-odds of experiencing CHD experiencing CHD 
+log-odds of experiencing CHD
 per one-year difference in age 
 between two individuals with type B personalities.
 

--- a/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
+++ b/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
@@ -54,8 +54,6 @@ anthers_glm_logit |>
   print_md()
 ```
 
-\[to add: fitted plots on each outcome scale\]
-
 ---
 
 When I try to use `link ="log"` in practice, I often get errors about

--- a/_subfiles/logistic-regression/_sec_OR-RR.qmd
+++ b/_subfiles/logistic-regression/_sec_OR-RR.qmd
@@ -46,3 +46,18 @@ odds(pi2) / odds(pi1)
 ---
 
 {{< include _subfiles/logistic-regression/_fig-rd-rr-or.qmd >}}
+
+---
+
+Testing whether an odds ratio = 1 is equivalent to
+testing whether the corresponding risk ratio = 1,
+and also equivalent to
+testing whether the risk difference = 0.
+Therefore,
+in **hypothesis testing**,
+if the null hypothesis is no effect,
+then we can shift between RD, RR, and OR.
+But when we're talking about **point estimates** and **CIs**,
+we need to limit our conclusions to the effect measure(s) that we actually estimated,
+because the *sizes* of RDs, RRs, and ORs don't have a simple relationship to each other,
+except when $\pi_1=\pi_2$ (as shown by @fig-rd-rr-or).

--- a/_subfiles/logistic-regression/_sec_OR_logistic.qmd
+++ b/_subfiles/logistic-regression/_sec_OR_logistic.qmd
@@ -85,7 +85,7 @@ $$\red{\difflogodds} \eqdef \red{\logodds(\vx) - \logodds(\vxs)}$$
 
 :::{#cor-logistic-OR}
 #### Shorthand general formula for odds ratios in logistic regression
-$$\ror(\vx,\vxs) = \expf{\red{\difflogodds}}$${#eq-logistic-ror}
+$$\ror(\vx,\vxs) = \expf{\red{\difflogodds}}$${#eq-logistic-ror-diff}
 :::
 
 ::: proof

--- a/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
+++ b/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
@@ -5,7 +5,7 @@ The risks are $P(MI|OC)$ and $P(MI|\neg OC)$ and we can estimate these risks fro
 
 But suppose we had a case-control study in which we had 100 women with MI and selected a comparison group of 100 women without MI (matched as groups on age, etc.).
 Then MI is not random, and we cannot compute P(MI|OC) and we cannot compute the risk ratio.
-However, the odds ratio however can be computed.
+However, the odds ratio can be computed.
 
 The disease odds ratio is the odds for the disease in the exposed group divided by the odds for the disease in the unexposed group, and we cannot validly compute and use these separate parts.
 
@@ -51,9 +51,9 @@ Simulated data from study of oral contraceptive use and heart attack risk
 
 :::
 
-* $\odds(OC|MI) = P(OC|MI)/(1 – P(OC|MI) = \frac{13}{7} = `r 13/7`$
+* $\odds(OC|MI) = P(OC|MI)/(1 - P(OC|MI)) = \frac{13}{7} = `r 13/7`$
 
-* $\odds(OC|\neg MI) = P(OC|\neg MI)/(1 – P(OC|\neg MI) = \frac{4987}{9993} = `r 4987/9993`$
+* $\odds(OC|\neg MI) = P(OC|\neg MI)/(1 - P(OC|\neg MI)) = \frac{4987}{9993} = `r 4987/9993`$
 
 * $\ror(OC,MI) = \frac{\odds(OC|MI)}{\odds(OC|\neg MI)} = \frac{13/7}{4987/9993} = `r (13/7)/(4987/9993)`$
 

--- a/_subfiles/logistic-regression/_sec_compare_probs.qmd
+++ b/_subfiles/logistic-regression/_sec_compare_probs.qmd
@@ -36,10 +36,10 @@ $$
 
 ---
 
-:::{#exr-interpret-rr}
+:::{#exr-interpret-rd}
 #### interpreting risk differences
 
-How can we interpret the preceding relative risk estimate in prose?
+How can we interpret the preceding risk difference estimate in prose?
 :::
 
 ---

--- a/_subfiles/logistic-regression/_sec_derive_logistic_hessian.qmd
+++ b/_subfiles/logistic-regression/_sec_derive_logistic_hessian.qmd
@@ -114,10 +114,10 @@ $$
 & \cdots 
 & \xderivf{\llik}{\beta_0}{\beta_p}
 \\
-\xderivf{\llik}{\beta_1}{\beta_0} 
-& \dderivf{\llik}{\beta_1} 
-& \cdots 
-& \xderivf{\llik}{\beta_0}{\beta_p}
+\xderivf{\llik}{\beta_1}{\beta_0}
+& \dderivf{\llik}{\beta_1}
+& \cdots
+& \xderivf{\llik}{\beta_1}{\beta_p}
 \\
 \vdots
 & \ddots

--- a/_subfiles/logistic-regression/_sec_expit.qmd
+++ b/_subfiles/logistic-regression/_sec_expit.qmd
@@ -47,7 +47,7 @@ $$
 \ba
 \expit(\logodds)
    &= \frac{\exp{\logodds}}{1+\exp{\logodds}}
-\\ &= \frac{1}{1 + \exp{-\logodds})}
+\\ &= \frac{1}{1 + \exp{-\logodds}}
 \\ &= (1 + \exp{-\logodds})^{-1}
 \ea
 $$

--- a/_subfiles/logistic-regression/_sec_logistic_dx.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_dx.qmd
@@ -344,8 +344,10 @@ chd_glm_contrasts_grouped |>
 
 ::: notes
 
-Things look pretty good here. The QQ plot is still usable; with large
-samples; the residuals should be approximately Gaussian.
+Things look pretty good here.
+The QQ plot is still usable:
+when the number of observations at each covariate pattern is large,
+the grouped residuals should be approximately Gaussian.
 
 :::
 

--- a/_subfiles/logistic-regression/_sec_odds_ratios.qmd
+++ b/_subfiles/logistic-regression/_sec_odds_ratios.qmd
@@ -12,23 +12,10 @@ Now that we have defined odds, we can introduce another way of comparing event p
 
 ---
 
-There's a 1:1 mapping between probability and odds, 
-and according to that mapping, 
-the odds are equal between two covariate patterns 
-IF and ONLY IF the probabilities are also equal between those patterns. 
-So, 
-testing whether an odds ratio = 1 is equivalent to 
-testing whether the corresponding risk ratio = 1, 
-and also equivalent to 
-testing whether the risk difference = 0.
-Therefore, 
-in **hypothesis testing**, 
-if the null hypothesis is no effect, 
-then we can shift between RD, RR, and OR.
-But when we're talking about **point estimates** and **CIs**, 
-we need to limit our conclusions to the effect measure(s) that we actually estimated, 
-because the *sizes* of RDs, RRs, and ORs don't have a simple relationship to each other, 
-except when pi_1=pi_2 (as shown by @fig-rd-rr-or). 
+There's a 1:1 mapping between probability and odds,
+and according to that mapping,
+the odds are equal between two covariate patterns
+IF and ONLY IF the probabilities are also equal between those patterns.
 
 ---
 

--- a/_subfiles/logistic-regression/_sec_wcgs_model_graphs.qmd
+++ b/_subfiles/logistic-regression/_sec_wcgs_model_graphs.qmd
@@ -8,6 +8,8 @@ log-odds).
 
 #### probability scale
 
+:::{#fig-fitted-probs-chd}
+
 ```{r}
 curve_type_A <- function(x) { # nolint: object_name_linter
   chd_glm_contrasts |> predict(
@@ -36,9 +38,15 @@ chd_plot_probs_2 <-
 print(chd_plot_probs_2)
 ```
 
+Fitted CHD risk by age and behavior pattern (probability scale)
+
+:::
+
 ---
 
-:::{fig-fitted-odds-chd}
+#### odds scale
+
+:::{#fig-fitted-odds-chd}
 
 ```{r}
 
@@ -55,7 +63,7 @@ chd_plot_odds_2 <-
 print(chd_plot_odds_2)
 ```
 
-odds scale
+Fitted CHD odds by age and behavior pattern (odds scale)
 
 :::
 
@@ -63,8 +71,9 @@ odds scale
 
 #### log-odds (logit) scale
 
+:::{#fig-fitted-log-odds}
+
 ```{r}
-#| label: fig-fitted-log-odds
 
 chd_plot_logit_2 <-
   chd_plot_logit +
@@ -79,3 +88,7 @@ chd_plot_logit_2 <-
 
 print(chd_plot_logit_2)
 ```
+
+Fitted CHD log-odds by age and behavior pattern (log-odds scale)
+
+:::

--- a/_subfiles/logistic-regression/_sec_wcgs_notation.qmd
+++ b/_subfiles/logistic-regression/_sec_wcgs_notation.qmd
@@ -1,4 +1,4 @@
-For the `wgcs` dataset, let's consider a **logistic regression model** for the outcome of
+For the `wcgs` dataset, let's consider a **logistic regression model** for the outcome of
 Coronary Heart Disease ($Y$; `chd` in computer output):
 
 - $Y = 1$ if an individual developed CHD by the end of the study;

--- a/_subfiles/logistic-regression/_thm_est_odds_shortcut.qmd
+++ b/_subfiles/logistic-regression/_thm_est_odds_shortcut.qmd
@@ -3,7 +3,7 @@
 
 Let $X_1,...X_n$ be a set of $n$ $\iid$ Bernoulli trials, and let $X = \sumin X_i$ be their sum.
 
-Then the maximum likelihood estimate of the odds of $X=1$, $\odds$, is:
+Then the maximum likelihood estimate of the common per-trial success odds $\odds$ (that is, the odds of $X_i=1$) is:
 
 $$
 \hat{\odds}= \frac{x}{n-x}

--- a/_subfiles/logistic-regression/_thm_odds_nonevent.qmd
+++ b/_subfiles/logistic-regression/_thm_odds_nonevent.qmd
@@ -1,7 +1,7 @@
 :::{#cor-odds-neg}
 #### Odds of a non-event
 
-If $\pi$ is the odds of event $A$
+If $\pi$ is the probability of event $A$
 and $\odds$ is the corresponding odds of $A$,
 then the odds of $\neg A$ are:
 


### PR DESCRIPTION
Closes #1024. Part of #1023 (workstream 1 of 9; the base of the PR stack — subsequent workstream PRs will be stacked on this branch).

Fixes the confirmed rendering/correctness defects found by the holistic chapter review:

- **`_sec_wcgs_model_graphs.qmd`** — `:::{fig-fitted-odds-chd}` was missing the `#`, so the div rendered as a literal class name on the live site (no figure numbering, empty caption). All three fitted-model scale plots now use uniform `:::{#fig-...}` divs with captions (`fig-fitted-probs-chd`, `fig-fitted-odds-chd`, `fig-fitted-log-odds` — verified present in the rendered HTML).
- **`_exm_wcgs_coef_interp.qmd`** — unmatched `)` in the interaction-term derivative line (rendered as a stray `)` live); duplicated phrase "experiencing CHD experiencing CHD".
- **`_sec_wcgs_notation.qmd`** — "`wgcs`" typo.
- **`_sec_compare_probs.qmd`** — duplicate crossref id `exr-interpret-rr` used for two different exercises; the first was an unadapted copy-paste asking about "the preceding relative risk estimate" while its own solution (`sol-interpret-rd`) interprets the risk difference. Renamed to `exr-interpret-rd` and fixed the body text.
- **`_thm_odds_nonevent.qmd`** (`cor-odds-neg`) — statement said "$\pi$ is the odds of event $A$"; $\pi$ is the probability.
- **`_thm_est_odds_shortcut.qmd`** — statement claimed the MLE of "the odds of $X=1$" where $X=\sum_i X_i$; the estimand is the common per-trial success odds (odds of $X_i=1$), a different quantity for $n&gt;1$.
- **`_sec_ORs-in-case-control_studies.qmd`** — unbalanced parentheses in both odds formulas, math-mode en-dashes, and a duplicated "however".
- **`_sec_expit.qmd`** — stray `)` in `thm-expit-expressions` (the `\exp{}` macro already closes its argument).
- **`_sec_odds_ratios.qmd` / `_sec_OR-RR.qmd`** — the hypothesis-testing note cited `@fig-rd-rr-or` before that figure appears in reading order; moved the note after the figure and fixed the literal `pi_1=pi_2` to `$\pi_1=\pi_2$`.
- **`_sec_OR_logistic.qmd`** — equation label `{#eq-logistic-ror}` was defined twice; the corollary's copy renamed to `{#eq-logistic-ror-diff}` (no existing references to the old label elsewhere — verified by grep).
- **`_sec_derive_logistic_hessian.qmd`** — row 2's final entry of the generic Hessian block matrix was a copy of row 1's ($\partial^2\ell/\partial\beta_0\partial\beta_p$); corrected to $\partial^2\ell/\partial\beta_1\partial\beta_p$.
- **`_sec-non-logistic-bernoulli-models.qmd`** — removed the unresolved `\[to add: fitted plots on each outcome scale\]` placeholder (adding the plots is tracked in #1029).
- **`_sec_logistic_dx.qmd`** — fixed the garbled double-semicolon QQ-plot note and stated the correct large-sample condition (per-covariate-pattern counts, not total $N$).

Pre-commit checklist: chapter renders clean to HTML (verified the three figure ids in the output), `lintr` clean on changed code (3 remaining hits are pre-existing code not touched by this PR), `spelling::spell_check_package()` clean.

Note on local verification: this sandbox blocks api.github.com, so `renv::restore()` cannot install the GitHub-pinned lockfile packages; the render check used CRAN/PPM versions of those packages and a local data-only stand-in for `rmb::wcgs` built from this repo's own `Data/wcgs.rda`. CI's renv-based render is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce

---
_Generated by [Claude Code](https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce)_