### PR TITLE
Sweep bare `---` → `{{< slidebreak >}}` in logistic-regression chapter

### DIFF
--- a/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
+++ b/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
@@ -60,7 +60,7 @@ $$
 \deriv{a}\eta(P=0, A = a) 
 &= \deriv{a} (\beta_0 + \beta_P 0 + \beta_A a + \beta_{PA}(0\cdot a))
 \\
-&= \deriv{a}\beta_0 + \deriv{a}\beta_P 0 + \deriv{a}\beta_A a + \deriv{a}\beta_{PA}(0\cdot a))
+&= \deriv{a}\beta_0 + \deriv{a}\beta_P 0 + \deriv{a}\beta_A a + \deriv{a}\beta_{PA}(0\cdot a)
 \\
 &=  0 + 0 + \beta_A + 0
 \\
@@ -85,7 +85,7 @@ $$
 
 That is,
 $\beta_{A}$ is the difference in 
-log-odds of experiencing CHD experiencing CHD 
+log-odds of experiencing CHD
 per one-year difference in age 
 between two individuals with type B personalities.
 

--- a/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
+++ b/_subfiles/logistic-regression/_exm_wcgs_coef_interp.qmd
@@ -11,7 +11,7 @@ State the interpretations concisely in math **and** in words.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-logistic-coef-interp}
 
@@ -38,7 +38,7 @@ $$\beta_{0} = \eta(P=0,A=0)$${#eq-wcgs-intxn-beta0}
 
 $\beta_{0}$ is the natural logarithm of the odds ("log-odds") of experiencing CHD for a `r age_offset` year-old person with a type B personality; that is,
 
----
+{{< slidebreak >}}
 
 $\text{e}^{\beta_{0}}$ is the odds of experiencing CHD 
 for a `r age_offset` year-old with a type B personality,
@@ -53,7 +53,7 @@ $$
 \end{aligned}
 $$
 
----
+{{< slidebreak >}}
 
 $$
 \ba
@@ -89,7 +89,7 @@ log-odds of experiencing CHD
 per one-year difference in age 
 between two individuals with type B personalities.
 
----
+{{< slidebreak >}}
 
 $$
 \ba
@@ -112,7 +112,7 @@ differs by a factor of $\text{e}^{\beta_{A}}$
 per one-year difference in age 
 between individuals with type B personality.
 
----
+{{< slidebreak >}}
 
 $\beta_{P}$ is the difference in log-odds of experiencing CHD
 for a `r age_offset` year-old person with type A personality
@@ -121,7 +121,7 @@ that is,
 
 $$\b_P = \eta(P = 1, A = 0) - \eta(P=0, A = 0)$${#eq-wcgs-intxn-betaP}
 
----
+{{< slidebreak >}}
 
 -   $\text{e}^{\beta_{P}}$ is the ratio of the odds (aka "the odds ratio")
     of experiencing CHD, 
@@ -135,7 +135,7 @@ $$
 {\oddst(Y= 1|P=0, A = 0)}
 $$
 
----
+{{< slidebreak >}}
 
 $$
 \ba
@@ -170,7 +170,7 @@ the slopes of log-odds over age between
 participants with Type A personalities and
 participants with Type B personalities.
 
----
+{{< slidebreak >}}
 
 Accordingly, 
 the odds ratio of experiencing CHD per one-year difference in age

--- a/_subfiles/logistic-regression/_exr-bernoulli-lik.qmd
+++ b/_subfiles/logistic-regression/_exr-bernoulli-lik.qmd
@@ -17,7 +17,7 @@ Write the likelihood of $\vy$.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-bernoulli-likelihood-general}
 
@@ -44,7 +44,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-bernoulli-loglik-general}
 
@@ -52,7 +52,7 @@ Write the log-likelihood of $\vy$.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-bernoulli-loglik-general}
 

--- a/_subfiles/logistic-regression/_exr-link-function-choice.qmd
+++ b/_subfiles/logistic-regression/_exr-link-function-choice.qmd
@@ -23,7 +23,7 @@ what constraint on the parameters ensures $\pi(x) \leq 1$ for all $x > 0$?
 Give one practical advantage of that link.
 :::
 
----
+{{< slidebreak >}}
 
 ::: {.solution}
 

--- a/_subfiles/logistic-regression/_sec-2x2-OR-shortcut.qmd
+++ b/_subfiles/logistic-regression/_sec-2x2-OR-shortcut.qmd
@@ -29,7 +29,7 @@ From this table, we have:
 * $\ror(Exposed,\neg Exposed) = \frac{\frac{a}{b}}{\frac{c}{d}} = \frac{ad}{bc}$
 
 
----
+{{< slidebreak >}}
 
 :::{#exr-odds-generic}
 Given @tbl-2x2-generic, show that $\hat\odds(Event|\neg Exposed) = \frac{c}{d}$.

--- a/_subfiles/logistic-regression/_sec-d_odds-d_logodds.qmd
+++ b/_subfiles/logistic-regression/_sec-d_odds-d_logodds.qmd
@@ -5,7 +5,7 @@ $$\derivf{\odds}{\logodds} = \odds$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -24,7 +24,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-d_odds-d_logodds}
 
@@ -34,7 +34,7 @@ $$\derivf{\omega}{\eta} = \frac{\pi}{1-\pi}$${#eq-d_omega-d_eta}
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 

--- a/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
+++ b/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
@@ -28,7 +28,7 @@ anthers_glm_log |>
   print_md()
 ```
 
----
+{{< slidebreak >}}
 
 Now $\exp{\beta}$ gives us risk ratios instead of odds ratios:
 
@@ -38,7 +38,7 @@ anthers_glm_log |>
   print_md()
 ```
 
----
+{{< slidebreak >}}
 
 Let's compare this model with a logistic model:
 
@@ -54,7 +54,7 @@ anthers_glm_logit |>
   print_md()
 ```
 
----
+{{< slidebreak >}}
 
 When I try to use `link ="log"` in practice, I often get errors about
 not finding good starting values for the estimation procedure.

--- a/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
+++ b/_subfiles/logistic-regression/_sec-non-logistic-bernoulli-models.qmd
@@ -54,8 +54,6 @@ anthers_glm_logit |>
   print_md()
 ```
 
-\[to add: fitted plots on each outcome scale\]
-
 ---
 
 When I try to use `link ="log"` in practice, I often get errors about

--- a/_subfiles/logistic-regression/_sec_OR-RR.qmd
+++ b/_subfiles/logistic-regression/_sec_OR-RR.qmd
@@ -46,3 +46,18 @@ odds(pi2) / odds(pi1)
 ---
 
 {{< include _subfiles/logistic-regression/_fig-rd-rr-or.qmd >}}
+
+---
+
+Testing whether an odds ratio = 1 is equivalent to
+testing whether the corresponding risk ratio = 1,
+and also equivalent to
+testing whether the risk difference = 0.
+Therefore,
+in **hypothesis testing**,
+if the null hypothesis is no effect,
+then we can shift between RD, RR, and OR.
+But when we're talking about **point estimates** and **CIs**,
+we need to limit our conclusions to the effect measure(s) that we actually estimated,
+because the *sizes* of RDs, RRs, and ORs don't have a simple relationship to each other,
+except when $\pi_1=\pi_2$ (as shown by @fig-rd-rr-or).

--- a/_subfiles/logistic-regression/_sec_OR-RR.qmd
+++ b/_subfiles/logistic-regression/_sec_OR-RR.qmd
@@ -19,13 +19,13 @@ pi2 / pi1
 odds(pi2) / odds(pi1)
 ```
 
----
+{{< slidebreak >}}
 
 :::{#exm-or-rr-OC-MI}
 In @exm-oc-mi, the outcome is rare for both OC and non-OC participants, so the odds for both groups are similar to the corresponding probabilities, and the odds ratio is similar the risk ratio.
 :::
 
----
+{{< slidebreak >}}
 
 ##### Case 2: frequent events
 
@@ -43,11 +43,11 @@ pi2 / pi1
 odds(pi2) / odds(pi1)
 ```
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_fig-rd-rr-or.qmd >}}
 
----
+{{< slidebreak >}}
 
 Testing whether an odds ratio = 1 is equivalent to
 testing whether the corresponding risk ratio = 1,

--- a/_subfiles/logistic-regression/_sec_OR_inference.qmd
+++ b/_subfiles/logistic-regression/_sec_OR_inference.qmd
@@ -10,7 +10,7 @@ calculate a 95% confidence interval for the odds ratio
 comparing covariate patterns $\vx$ and $\vxs$, $\ror(\vx,\vxs)$.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-ci-OR}
 
@@ -36,7 +36,7 @@ $$\ror(\vx,\vxs) \in (e^L, e^R)$${#eq-ci-OR-exp}
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-or-diff-logodds}
 
@@ -45,7 +45,7 @@ $\logf{\ror(\vx,\vxs)}$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-or-diff-logodds}
 
@@ -61,7 +61,7 @@ $$\hdifflogodds \pm 1.96 * \blue{\HSE{\hdifflogodds}}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-se-diff-logodds}
 
@@ -74,7 +74,7 @@ $$\blue{\HSE{\hdifflogodds}} = \blue{?}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-se-diff-logodds}
 
@@ -98,7 +98,7 @@ $${#eq-var-diff-logodds}
 
 where $\Sigma \eqdef \Covt(\hb)$.
 
----
+{{< slidebreak >}}
 
 ::: notes
 Expanding @eq-var-diff-logodds out of matrix-vector notation, we have:
@@ -115,7 +115,7 @@ $$
 \ea
 $$
 
----
+{{< slidebreak >}}
 
 Combining @eq-var-diff-logodds and MLE invariance:
 

--- a/_subfiles/logistic-regression/_sec_OR_logistic.qmd
+++ b/_subfiles/logistic-regression/_sec_OR_logistic.qmd
@@ -22,7 +22,7 @@ $$\ror(\vx,\vxs) \eqdef \frac{\odds(\vx)}{\odds(\vxs)}$${#eq-def-ror}
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-logistic-OR}
 #### General formula for odds ratios in logistic regression
@@ -39,7 +39,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: notes
 @sol-logistic-OR is more concrete than @eq-def-ror,
@@ -58,7 +58,7 @@ $$\ror(\vx,\vxs) = \expf{\red{\logodds(\vx) - \logodds(\vxs)}}$${#eq-logistic-ro
 By @sol-logistic-OR.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#def-difflogodds}
 #### Difference in log-odds
@@ -81,7 +81,7 @@ $$\red{\difflogodds} \eqdef \red{\logodds(\vx) - \logodds(\vxs)}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-logistic-OR}
 #### Shorthand general formula for odds ratios in logistic regression
@@ -92,7 +92,7 @@ $$\ror(\vx,\vxs) = \expf{\red{\difflogodds}}$${#eq-logistic-ror-diff}
 By @lem-logistic-OR and @def-difflogodds.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-diff-logodds}
 #### Difference in log-odds
@@ -101,7 +101,7 @@ the difference in log-odds:
 $$\difflogodds \eqdef \red{\logodds(\vx) - \logodds(\vxs)}$$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-diff-logodds}
 #### Difference in log-odds
@@ -124,7 +124,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#lem-diff-logodds}
 #### Difference in log-odds
@@ -135,7 +135,7 @@ $$\red{\difflogodds}= (\blue{\vx - \vxs})\cdot\vb$$
 By @sol-diff-logodds.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#def-diff-covs}
 #### Difference in covariate patterns
@@ -155,7 +155,7 @@ is defined as:
 $$\blue{\diffvx} \eqdef \blue{\vx - \vxs}$$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-diff-logodds}
 #### Difference in log-odds
@@ -167,7 +167,7 @@ $$\red{\difflogodds}= (\blue{\diffvx}) \cdot \vb$$
 By @lem-diff-logodds and @def-diff-covs.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-simplify-logistic-OR}
 
@@ -176,7 +176,7 @@ in terms of $\diffvx$ and $\vb$.
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: {#sol-simplify-logistic-OR}
 
@@ -193,7 +193,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-logistic-OR}
 
@@ -209,7 +209,7 @@ The odds ratio comparing covariate patterns $\vx$ and $\vxs$ is:
 By @sol-simplify-logistic-OR.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-log-or}
 

--- a/_subfiles/logistic-regression/_sec_OR_logistic.qmd
+++ b/_subfiles/logistic-regression/_sec_OR_logistic.qmd
@@ -85,7 +85,7 @@ $$\red{\difflogodds} \eqdef \red{\logodds(\vx) - \logodds(\vxs)}$$
 
 :::{#cor-logistic-OR}
 #### Shorthand general formula for odds ratios in logistic regression
-$$\ror(\vx,\vxs) = \expf{\red{\difflogodds}}$${#eq-logistic-ror}
+$$\ror(\vx,\vxs) = \expf{\red{\difflogodds}}$${#eq-logistic-ror-diff}
 :::
 
 ::: proof

--- a/_subfiles/logistic-regression/_sec_OR_objections.qmd
+++ b/_subfiles/logistic-regression/_sec_OR_objections.qmd
@@ -8,7 +8,7 @@ the odds ratio is not very closely correlated with the risk difference,
 and the risk difference is typically the metric 
 that ultimately matters for policy decisions.
 
----
+{{< slidebreak >}}
 
 ::: notes
 
@@ -44,7 +44,7 @@ we can't change the order of the expectation and $\expitf{}$ operators:
 
 $$\Expf{\expitf{\eta_0 + \b_XX + \b_CC} | X} \neq \expitf{\Expf{\eta_0 + \b_XX + \b_CC} | X}$$
 
----
+{{< slidebreak >}}
 
 In contrast, consider a model with an identity link function:
 
@@ -90,7 +90,7 @@ then the slope with respect to $X$ doesn't depend on
 whether $C$ is included in the model
 (and an analogous result holds if $X$ is discrete or categorical).
 
----
+{{< slidebreak >}}
 
 :::{#exr-marginal-model-non-indep}
 
@@ -100,7 +100,7 @@ if $\Ef{C|X=x} = \gamma_0 + \gamma_x x$?
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-marginal-model-non-indep}
 
@@ -108,7 +108,7 @@ Left to the reader.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-marginal-model-non-indep-interaction}
 
@@ -120,7 +120,7 @@ and $\Ef{C|X=x} = \gamma_0 + \gamma_x x$?
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-marginal-model-non-indep-interaction}
 

--- a/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
+++ b/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
@@ -27,7 +27,7 @@ are mathematically equivalent, as we saw in @sec-OR-props:
 
 $$\hth(MI|OC) = \hth(OC|MI)$$
 
----
+{{< slidebreak >}}
 
 :::{#exr-or-rev}
 
@@ -37,7 +37,7 @@ Confirm that the result is the same as in @exm-OR.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::: {.solution}
 

--- a/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
+++ b/_subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd
@@ -5,7 +5,7 @@ The risks are $P(MI|OC)$ and $P(MI|\neg OC)$ and we can estimate these risks fro
 
 But suppose we had a case-control study in which we had 100 women with MI and selected a comparison group of 100 women without MI (matched as groups on age, etc.).
 Then MI is not random, and we cannot compute P(MI|OC) and we cannot compute the risk ratio.
-However, the odds ratio however can be computed.
+However, the odds ratio can be computed.
 
 The disease odds ratio is the odds for the disease in the exposed group divided by the odds for the disease in the unexposed group, and we cannot validly compute and use these separate parts.
 
@@ -51,9 +51,9 @@ Simulated data from study of oral contraceptive use and heart attack risk
 
 :::
 
-* $\odds(OC|MI) = P(OC|MI)/(1 – P(OC|MI) = \frac{13}{7} = `r 13/7`$
+* $\odds(OC|MI) = P(OC|MI)/(1 - P(OC|MI)) = \frac{13}{7} = `r 13/7`$
 
-* $\odds(OC|\neg MI) = P(OC|\neg MI)/(1 – P(OC|\neg MI) = \frac{4987}{9993} = `r 4987/9993`$
+* $\odds(OC|\neg MI) = P(OC|\neg MI)/(1 - P(OC|\neg MI)) = \frac{4987}{9993} = `r 4987/9993`$
 
 * $\ror(OC,MI) = \frac{\odds(OC|MI)}{\odds(OC|\neg MI)} = \frac{13/7}{4987/9993} = `r (13/7)/(4987/9993)`$
 

--- a/_subfiles/logistic-regression/_sec_ORs_reversible.qmd
+++ b/_subfiles/logistic-regression/_sec_ORs_reversible.qmd
@@ -13,7 +13,7 @@ $$\ror(A|B) = \ror(B|A)$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: {.proof}
 
@@ -21,7 +21,7 @@ $$\ror(A|B) = \ror(B|A)$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exm-or-inv-MI}
 
@@ -55,13 +55,13 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-2x2-generic}
 For @tbl-2x2-generic, show that $\hat\ror(Exposed, Unexposed) = \hat\ror(Event, \neg Event)$.
 :::
 
----
+{{< slidebreak >}}
 
 :::: notes
 Conditional odds ratios have the same reversibility property:
@@ -76,7 +76,7 @@ For any three events $A$, $B$, $C$:
 $$\ror(A|B,C) = \ror(B|A,C)$$
 :::
 
----
+{{< slidebreak >}}
 
 :::{.proof}
 Apply the same steps as for @thm-or-swap,

--- a/_subfiles/logistic-regression/_sec_compare_probs.qmd
+++ b/_subfiles/logistic-regression/_sec_compare_probs.qmd
@@ -10,7 +10,7 @@ The **risk difference** of two probabilities, $\pi_1$, and $\pi_2$, is the diffe
 $$\delta(\pi_1,\pi_2) \eqdef \pi_1 - \pi_2$$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exm-RD}
 
@@ -34,7 +34,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-interpret-rd}
 #### interpreting risk differences
@@ -42,7 +42,7 @@ $$
 How can we interpret the preceding risk difference estimate in prose?
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-interpret-rd}
 
@@ -61,7 +61,7 @@ or
 See the note about working with percentages in the [Appendix](notation.qmd#percent-sign).
 :::
 
----
+{{< slidebreak >}}
 
 ### Risk ratios
 
@@ -73,7 +73,7 @@ what do we call the following ratio?
 $$\rho(\pi_1,\pi_2) = \frac{\pi_1}{\pi_2}$$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-exr-name-RR}
 
@@ -98,7 +98,7 @@ of $\pi_1$ compared to $\pi_2$.
 :::
 
 
----
+{{< slidebreak >}}
 
 :::{#exr-RR}
 
@@ -114,7 +114,7 @@ Now, estimate the *relative risk* of MI for OC versus non-OC.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-exr-RR}
 
@@ -138,13 +138,13 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-interpret-rr}
 How can we interpret the preceding relative risk estimate in prose?
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-interpret-rr}
 
@@ -168,7 +168,7 @@ see also [Section 8.1.4](https://link.springer.com/chapter/10.1007/978-1-4614-13
 
 :::
 
----
+{{< slidebreak >}}
 
 ### Relative risk differences
 
@@ -190,7 +190,7 @@ $$\xi(\pi_1,\pi_2) \eqdef \frac{\delta(\pi_1,\pi_2)}{\pi_2}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-rrd-vs-rr}
 #### Relative risk difference equals risk ratio minus 1
@@ -198,7 +198,7 @@ $$\xi(\pi_1,\pi_2) \eqdef \frac{\delta(\pi_1,\pi_2)}{\pi_2}$$
 $$\xi(\pi_1,\pi_2) = \rho(\pi_1,\pi_2) - 1$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 $$
@@ -212,7 +212,7 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 ### Changing reference groups in risk comparisons
 
@@ -231,7 +231,7 @@ Prove the relationships above.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exm-ref}
 

--- a/_subfiles/logistic-regression/_sec_compare_probs.qmd
+++ b/_subfiles/logistic-regression/_sec_compare_probs.qmd
@@ -36,10 +36,10 @@ $$
 
 ---
 
-:::{#exr-interpret-rr}
+:::{#exr-interpret-rd}
 #### interpreting risk differences
 
-How can we interpret the preceding relative risk estimate in prose?
+How can we interpret the preceding risk difference estimate in prose?
 :::
 
 ---

--- a/_subfiles/logistic-regression/_sec_d-pi_d-eta.qmd
+++ b/_subfiles/logistic-regression/_sec_d-pi_d-eta.qmd
@@ -5,7 +5,7 @@
 $$\derivf{\prob}{\logodds} = \pi (1-\pi)$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -37,7 +37,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-d_pi-d_eta-var}
 

--- a/_subfiles/logistic-regression/_sec_derive_logistic_hessian.qmd
+++ b/_subfiles/logistic-regression/_sec_derive_logistic_hessian.qmd
@@ -16,11 +16,11 @@ $$
 \ea
 $${#eq-logit-hessian-i}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_thm-d_pi_d_beta.qmd >}}
 
----
+{{< slidebreak >}}
 
 Using @thm-d_pi_d_beta:
 
@@ -44,7 +44,7 @@ $$
 \ea
 $$
 
----
+{{< slidebreak >}}
 
 Returning to @eq-logit-hessian-i:
 
@@ -55,7 +55,7 @@ $$
 \ea
 $${#eq-logit-hessian-i-2}
 
----
+{{< slidebreak >}}
 
 Returning to @eq-logit-hessian:
 
@@ -79,7 +79,7 @@ $$
 \ea
 $${#eq-linear-hess}
 
----
+{{< slidebreak >}}
 
 :::{#exr-hess-logistic}
 
@@ -87,7 +87,7 @@ Determine the elements of the Hessian matrix for logistic regression.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-hess-logistic}
 
@@ -134,7 +134,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-hess-beetles}
 
@@ -142,7 +142,7 @@ Determine the Hessian for the `beetles` model.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-hess-beetles}
 

--- a/_subfiles/logistic-regression/_sec_derive_logistic_hessian.qmd
+++ b/_subfiles/logistic-regression/_sec_derive_logistic_hessian.qmd
@@ -114,10 +114,10 @@ $$
 & \cdots 
 & \xderivf{\llik}{\beta_0}{\beta_p}
 \\
-\xderivf{\llik}{\beta_1}{\beta_0} 
-& \dderivf{\llik}{\beta_1} 
-& \cdots 
-& \xderivf{\llik}{\beta_0}{\beta_p}
+\xderivf{\llik}{\beta_1}{\beta_0}
+& \dderivf{\llik}{\beta_1}
+& \cdots
+& \xderivf{\llik}{\beta_1}{\beta_p}
 \\
 \vdots
 & \ddots

--- a/_subfiles/logistic-regression/_sec_derive_logistic_loglik.qmd
+++ b/_subfiles/logistic-regression/_sec_derive_logistic_loglik.qmd
@@ -6,7 +6,7 @@ Find the log-likelihood function for the general logistic regression model.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-logistic-loglik}
 

--- a/_subfiles/logistic-regression/_sec_derivs_expit.qmd
+++ b/_subfiles/logistic-regression/_sec_derivs_expit.qmd
@@ -3,7 +3,7 @@
 
 {{< include _subfiles/logistic-regression/_sec-d_odds-d_logodds.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_d-pi_d-eta.qmd >}}
 

--- a/_subfiles/logistic-regression/_sec_derivs_logit.qmd
+++ b/_subfiles/logistic-regression/_sec_derivs_logit.qmd
@@ -6,7 +6,7 @@
 $$\derivf{\logodds}{\odds} = \odds^{-1}$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -22,7 +22,7 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-d_logodds-d_odds}
 
@@ -31,7 +31,7 @@ $$
 $$\derivf{\logodds}{\odds} = \frac{1-\pi}{\pi}$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -47,7 +47,7 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-d_logodds-d_prob}
 
@@ -56,7 +56,7 @@ $$
 $$\derivf{\logodds}{\prob} = \frac{1}{(\prob)(1-\prob)}$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -75,7 +75,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-deriv-logit}
 
@@ -84,7 +84,7 @@ $$
 $$\logit'(\prob) = \frac{1}{(\prob)(1-\prob)}$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 

--- a/_subfiles/logistic-regression/_sec_exm_wcgs.qmd
+++ b/_subfiles/logistic-regression/_sec_exm_wcgs.qmd
@@ -39,7 +39,7 @@ A copy is also available on
 wcgs
 ```
 
----
+{{< slidebreak >}}
 
 ### Data cleaning
 
@@ -177,7 +177,7 @@ chd_plot_probs <-
 print(chd_plot_probs)
 ```
 
----
+{{< slidebreak >}}
 
 ## Odds scale
 
@@ -205,7 +205,7 @@ chd_plot_odds <- chd_plot_probs +
 print(chd_plot_odds)
 ```
 
----
+{{< slidebreak >}}
 
 ## Log-odds (logit) scale
 
@@ -279,7 +279,7 @@ chd_glm_contrasts |>
   print_md()
 ```
 
----
+{{< slidebreak >}}
 
 We can get the corresponding odds ratio estimates ($e^{\hat{\beta}}$s) 
 by passing `exponentiate = TRUE` to `parameters()`:
@@ -315,7 +315,7 @@ chd_glm_strat |>
   print_md()
 ```
 
----
+{{< slidebreak >}}
 
 Again, we can get the corresponding odds ratios ($e^{\beta}$s) by passing
 `exponentiate = TRUE` to `parameters()`:
@@ -330,7 +330,7 @@ chd_glm_strat |>
 
 Compare with @tbl-model-corner-point.
 
----
+{{< slidebreak >}}
 
 :::{#exr-strat-to-contrast}
 If I give you model 1, how would you get the coefficients of model 2?

--- a/_subfiles/logistic-regression/_sec_expit.qmd
+++ b/_subfiles/logistic-regression/_sec_expit.qmd
@@ -47,7 +47,7 @@ $$
 \ba
 \expit(\logodds)
    &= \frac{\exp{\logodds}}{1+\exp{\logodds}}
-\\ &= \frac{1}{1 + \exp{-\logodds})}
+\\ &= \frac{1}{1 + \exp{-\logodds}}
 \\ &= (1 + \exp{-\logodds})^{-1}
 \ea
 $$

--- a/_subfiles/logistic-regression/_sec_expit.qmd
+++ b/_subfiles/logistic-regression/_sec_expit.qmd
@@ -1,6 +1,6 @@
 {{< include _subfiles/logistic-regression/_thm_odds-from-logodds.qmd >}}
 
----
+{{< slidebreak >}}
 
 :::{#thm-prob-from-logodds}
 
@@ -17,13 +17,13 @@ $$\prob = \frac{\expf{\eta}}{1+\expf{\eta}}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 Apply @thm-odds-to-prob and then @lem-odds-from-logodds.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#def-expit}
 
@@ -37,7 +37,7 @@ $$\expit(\logodds) \eqdef \invoddsf{\expf{\logodds}}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-expit-expressions}
 
@@ -53,14 +53,14 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 Apply definitions and @lem-invodds-simplified.
 Details left to the reader.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-expit-prob-logodds}
 #### Probability via the expit function
@@ -73,14 +73,14 @@ $$\prob = \expitf{\logodds}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
 Apply @thm-prob-from-logodds and @thm-expit-expressions.
 :::
 
----
+{{< slidebreak >}}
 
 @fig-expit-plot graphs the expit function.
 
@@ -106,6 +106,6 @@ expit_plot <-
 print(expit_plot)
 ```
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_logit-expit_inverse.qmd >}}

--- a/_subfiles/logistic-regression/_sec_intro_bernoulli_models.qmd
+++ b/_subfiles/logistic-regression/_sec_intro_bernoulli_models.qmd
@@ -13,7 +13,7 @@ with a special focus on risk ratios and odds ratios,
 which are important concepts for interpreting logistic regression.
 :::
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_risk_estimation.qmd >}}
 

--- a/_subfiles/logistic-regression/_sec_intro_wcgs.qmd
+++ b/_subfiles/logistic-regression/_sec_intro_wcgs.qmd
@@ -11,7 +11,7 @@ Let's use the data from the Western Collaborative Group Study (WCGS)
 epidemiological study designed to investigate the association between
 the "type A" behavior pattern and coronary heart disease (CHD)".
 
----
+{{< slidebreak >}}
 
 :::{#exr-def-type-A}
 
@@ -19,7 +19,7 @@ What is "type A" behavior?
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-def-type-A}
 *From Wikipedia, "Type A and Type B personality theory":*
@@ -35,7 +35,7 @@ although they have a greater tendency to disregard physical or mental
 stress when they do not achieve."
 :::
 
----
+{{< slidebreak >}}
 
 #### Study design
 
@@ -55,7 +55,7 @@ screening, the study population dropped to 3,154 and the number of
 companies to 10 because of various exclusions. The cohort comprised both
 blue- and white-collar employees.
 
----
+{{< slidebreak >}}
 
 ### Baseline data collection
 
@@ -73,14 +73,14 @@ socio-demographic characteristics:
 -   electrocardiogram
 -   corneal arcus
 
----
+{{< slidebreak >}}
 
 biochemical measurements:
 
 -   cholesterol and lipoprotein fractions;
 -   medical and family history and use of medications;
 
----
+{{< slidebreak >}}
 
 behavioral data:
 
@@ -89,7 +89,7 @@ behavioral data:
 -   exercise
 -   alcohol use.
 
----
+{{< slidebreak >}}
 
 Later surveys added data on:
 

--- a/_subfiles/logistic-regression/_sec_invodds.qmd
+++ b/_subfiles/logistic-regression/_sec_invodds.qmd
@@ -10,7 +10,7 @@ For example, if $\odds = 3/2$, what is $\prob$?
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-odds-to-prob}
 
@@ -47,7 +47,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 
 :::{#thm-odds-to-prob}
@@ -62,7 +62,7 @@ $$\pi = \frac{\odds}{1+\odds}$${#eq-prob-from-odds}
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -70,7 +70,7 @@ By @thm-prob-to-odds and @sol-odds-to-prob.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#def-inv-odds}
 
@@ -84,7 +84,7 @@ can be called the **inverse-odds function**.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-invodds-pi}
 
@@ -93,13 +93,13 @@ can be called the **inverse-odds function**.
 $$\prob = \invoddsf{\odds}$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 By @def-inv-odds and @thm-odds-to-prob.
 :::
 
----
+{{< slidebreak >}}
 
 
 :::{#cor-invodds-odds-inv}
@@ -110,7 +110,7 @@ $$\invoddsf{\odds} = \oddsinvf{\odds}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -134,7 +134,7 @@ Likewise (not shown):
 $$\oddsf{\invoddsf{\odds}} = \odds$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: notes
 The inverse-odds function converts odds into their corresponding probabilities (@fig-inv-odds).
@@ -159,7 +159,7 @@ ggplot() +
 The inverse odds function, $\invoddsf{\odds}$
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-odds-probs}
 
@@ -167,7 +167,7 @@ What probability corresponds to an odds of $\odds = 1$, and what is the numerica
 
 :::
 
----
+{{< slidebreak >}}
 
 ::::{.solution}
 $$
@@ -192,7 +192,7 @@ $$
 
 ::::
 
----
+{{< slidebreak >}}
 
 :::{#lem-invodds-simplified}
 
@@ -213,13 +213,13 @@ $$ {#eq-inv-odds-reduced}
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-inv-odds2}
 Prove that @eq-inv-odds-reduced is equivalent to @def-inv-odds.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-inv-odds2}
 
@@ -227,7 +227,7 @@ Analogous to @sol-odds2.
 
 :::
 
----
+{{< slidebreak >}}
 
 
 :::{#lem-one-minus-odds-inv}
@@ -237,7 +237,7 @@ $$1 - \prob = \frac{1}{1+\odds}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: {.proof}
 
@@ -255,7 +255,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-inverse-odds-nonevent}
 #### One plus odds in terms of non-event probability

--- a/_subfiles/logistic-regression/_sec_invodds_derivs.qmd
+++ b/_subfiles/logistic-regression/_sec_invodds_derivs.qmd
@@ -4,7 +4,7 @@
 $$\dinvoddsf{\odds} = \derivf{\prob}{\odds} = (1-\prob)^2 = \frac{1}{\sqf{1+\odds}} $${#eq-d_prob-d_odds}
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 

--- a/_subfiles/logistic-regression/_sec_logistic-fitting.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic-fitting.qmd
@@ -65,7 +65,7 @@ beetles_glm |>
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-beetles-likelihood}
 
@@ -135,19 +135,19 @@ increase `n_points` to improve render quality.
 
 :::
 
----
+{{< slidebreak >}}
 
 ### Log-likelihood function
 
 {{< include _subfiles/logistic-regression/_sec_derive_logistic_loglik.qmd >}}
 
----
+{{< slidebreak >}}
 
 :::{#exr-beetles-loglik}
 Compute and graph the log-likelihood for the `beetles` data.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-beetles-loglik}
 
@@ -198,7 +198,7 @@ log-likelihood of `beetles` data
 
 :::
 
----
+{{< slidebreak >}}
 
 Let's center dose:
 
@@ -228,7 +228,7 @@ beetles_glm_grouped_centered |>
   parameters::print_md()
 ```
 
----
+{{< slidebreak >}}
 
 ```{r}
 #| label: beetles-lik-centered-fig
@@ -287,7 +287,7 @@ Likelihood of `beetles` data (centered model)
 
 :::
 
----
+{{< slidebreak >}}
 
 ```{r}
 odds_inv <- function(omega) (1 + omega^-1)^-1
@@ -329,13 +329,13 @@ log-likelihood of `beetles` data (centered model)
 
 :::
 
----
+{{< slidebreak >}}
 
 ### Score function
 
 {{< include _subfiles/logistic-regression/_sec_logistic_score_fn.qmd >}}
 
----
+{{< slidebreak >}}
 
 :::{#exr-beetles-score}
 
@@ -343,7 +343,7 @@ Implement and graph the score function for the beetles data
 
 :::
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_score_graph.qmd >}}
 
@@ -352,7 +352,7 @@ Implement and graph the score function for the beetles data
 
 {{< include _subfiles/logistic-regression/_sec_derive_logistic_hessian.qmd >}}
 
----
+{{< slidebreak >}}
 
 Setting $\ell'(\vb; \vy) = 0$ gives us:
 
@@ -360,7 +360,7 @@ Setting $\ell'(\vb; \vy) = 0$ gives us:
 $$\sumin \cb{\vx_i(y_i - \expitf{\vx_i'\beta}) } = 0$$ {#eq-score-logistic}
 
 
----
+{{< slidebreak >}}
 
 ::: notes
 
@@ -409,7 +409,7 @@ the likelihood wasn't changing much anymore.
 
 :::
 
----
+{{< slidebreak >}}
 
 @tbl-beetles-glm-ungrouped and @tbl-beetles-glm-ungrouped-vcov show 
 the fitted model and the covariance matrix of the estimates, respectively.

--- a/_subfiles/logistic-regression/_sec_logistic_dx.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_dx.qmd
@@ -26,7 +26,7 @@ chd_glm_contrasts |> autoplot()
 ```
 
 
----
+{{< slidebreak >}}
 
 ::: notes
 
@@ -351,7 +351,7 @@ the grouped residuals should be approximately Gaussian.
 
 :::
 
----
+{{< slidebreak >}}
 
 #### Beetles
 

--- a/_subfiles/logistic-regression/_sec_logistic_dx.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_dx.qmd
@@ -344,8 +344,10 @@ chd_glm_contrasts_grouped |>
 
 ::: notes
 
-Things look pretty good here. The QQ plot is still usable; with large
-samples; the residuals should be approximately Gaussian.
+Things look pretty good here.
+The QQ plot is still usable:
+when the number of observations at each covariate pattern is large,
+the grouped residuals should be approximately Gaussian.
 
 :::
 

--- a/_subfiles/logistic-regression/_sec_logistic_pred_inference.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_pred_inference.qmd
@@ -12,7 +12,7 @@ $\pi(\vx) = \Pr(Y = 1 | \vX = \vx)$.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-ci-prob}
 
@@ -41,7 +41,7 @@ $$\pi(\vx) \in (\expit(L), \expit(R))$${#eq-ci-prob-exp}
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-logodds-ci}
 
@@ -49,7 +49,7 @@ Find a 95% confidence interval for the log-odds $\logodds(\vx) = \vx'\vb$.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-logodds-ci}
 
@@ -63,7 +63,7 @@ where $\hat\logodds(\vx) = \vx'\hb$.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-se-logodds}
 
@@ -78,7 +78,7 @@ $$\blue{\HSE{\hat\logodds(\vx)}} = \blue{?}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-se-logodds}
 
@@ -103,7 +103,7 @@ $${#eq-var-logodds}
 
 where $\Sigma \eqdef \Covt(\hb)$.
 
----
+{{< slidebreak >}}
 
 ::: notes
 
@@ -120,7 +120,7 @@ $$
 \ea
 $$
 
----
+{{< slidebreak >}}
 
 Combining @eq-var-logodds and MLE invariance:
 
@@ -148,7 +148,7 @@ our estimate of $\Sigma$.
 
 :::
 
----
+{{< slidebreak >}}
 
 #### In R
 

--- a/_subfiles/logistic-regression/_sec_logistic_score_fn.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_score_fn.qmd
@@ -17,7 +17,7 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 Starting from @lem-logistic-loglik-component, 
 we can apply the [vector chain rule](math-prereqs.qmd#thm-chain-vec):
@@ -38,7 +38,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#lem-d_logodds-d_vb}
 
@@ -64,11 +64,11 @@ whereas @lem-d_logodds-d_vb differentiates by $\vb$.
 :::
 
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_thm-d_odds_d_beta.qmd >}}
 
----
+{{< slidebreak >}}
 
 Now we can combine 
 @lem-logistic-score-comp,
@@ -105,7 +105,7 @@ $$\magenta{\llik_i'(\vb)} = \magenta{\vx_i \err_i}$${#eq-score-comp}
 This last expression is essentially the same as we found in [linear regression](Linear-models-overview.qmd#eq-scorefun-linreg).
 :::
 
----
+{{< slidebreak >}}
 
 Finally, 
 combining @lem-score-logistic and @thm-logistic-score-comp, 
@@ -126,7 +126,7 @@ $${#eq-logit-score}
 
 :::
 
----
+{{< slidebreak >}}
 
 The score function is vector-valued; 
 its components are:
@@ -172,7 +172,7 @@ $$\sumin \eps_i = 0$$
 
 $$\vx_j \cdot \veps = \sumin x_{ij} \eps_i = 0, \forall j \in \set{1:p}$$
 
----
+{{< slidebreak >}}
 
 :::{#exm-score-beetles}
 

--- a/_subfiles/logistic-regression/_sec_logistic_slope_mean.qmd
+++ b/_subfiles/logistic-regression/_sec_logistic_slope_mean.qmd
@@ -15,7 +15,7 @@ $$
 $$
 :::
 
----
+{{< slidebreak >}}
 
 
 :::{#exr-logistic-slope}
@@ -37,7 +37,7 @@ $$\derivf{\pi}{x} = ?$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-logistic-slope}
 

--- a/_subfiles/logistic-regression/_sec_logit-expit_inverse.qmd
+++ b/_subfiles/logistic-regression/_sec_logit-expit_inverse.qmd
@@ -7,7 +7,7 @@ $$\expitf{\logitf{\pi}} = \pi$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{.proof}
 Left to the reader.

--- a/_subfiles/logistic-regression/_sec_logit.qmd
+++ b/_subfiles/logistic-regression/_sec_logit.qmd
@@ -11,7 +11,7 @@ $$\logodds \eqdef \logf{\omega}$${#eq-def-logodds}
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-logodds-pi}
 
@@ -26,13 +26,13 @@ $$\logodds = \logf{\frac{\prob}{1-\prob}}$${#eq-logodds-from-prob}
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 Apply @def-logodds and then @thm-prob-to-odds.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#def-logit-fn}
 
@@ -53,7 +53,7 @@ The **logit function** is a [composite function](https://en.wikipedia.org/wiki/F
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-prove-eq-logit}
 
@@ -63,7 +63,7 @@ Mathematically expand the definition of the logit function.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-prove-eq-logit}
 #### Compose the logit function
@@ -80,7 +80,7 @@ Apply @def-logit-fn and then @def-odds (details left to the reader).
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-logodds-logit}
 #### Log-odds via the logit function
@@ -92,7 +92,7 @@ $$\logodds = \logitf{\prob}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -100,7 +100,7 @@ Apply @thm-logodds-pi and @thm-logit-function.
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: notes
 @fig-logit shows the shape of the $\logit()$ function.

--- a/_subfiles/logistic-regression/_sec_logreg_in_R.qmd
+++ b/_subfiles/logistic-regression/_sec_logreg_in_R.qmd
@@ -29,7 +29,7 @@ logistic regression model for beetles data with grouped (binomial) data
 
 :::
 
----
+{{< slidebreak >}}
 
 #### Fitted values
 
@@ -43,7 +43,7 @@ fitted(beetles_glm_grouped)
 predict(beetles_glm_grouped, type = "response")
 ```
 
----
+{{< slidebreak >}}
 
 #### Count scale
 
@@ -54,7 +54,7 @@ we can convert to the count scale by multiplying by the group size:
 beetles$n * fitted(beetles_glm_grouped)
 ```
 
----
+{{< slidebreak >}}
 
 
 #### Logit scale
@@ -64,7 +64,7 @@ predict(beetles_glm_grouped, type = "link")
 
 ```
 
----
+{{< slidebreak >}}
 
 Converting between logit and probability scales works as expected:
 
@@ -76,7 +76,7 @@ predict(beetles_glm_grouped, type = "response") |> arm::logit()
 predict(beetles_glm_grouped, type = "link")
 ```
 
----
+{{< slidebreak >}}
 
 `type = "terms"` is confusing, because the variables get centered:
 
@@ -85,7 +85,7 @@ predict(beetles_glm_grouped, type = "terms")
 coef(beetles_glm_grouped)["dose"] * beetles$dose
 ```
 
----
+{{< slidebreak >}}
 
 We can construct the link-scale predictions from the terms:
 
@@ -95,7 +95,7 @@ terms_pred + attr(terms_pred, "constant")
 predict(beetles_glm_grouped, type = "link")
 ```
 
----
+{{< slidebreak >}}
 
 #### Individual observations
 
@@ -106,7 +106,7 @@ predict(beetles_glm_grouped, type = "link")
 beetles_long
 ```
 
----
+{{< slidebreak >}}
 
 :::{#tbl-beetles-model-ungrouped}
 
@@ -132,7 +132,7 @@ logistic regression model for beetles data with individual Bernoulli data
 Compare this model with the grouped-observations model (@tbl-beetles-model-grouped).
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-compare-grouped-ungrouped}
 

--- a/_subfiles/logistic-regression/_sec_odds.qmd
+++ b/_subfiles/logistic-regression/_sec_odds.qmd
@@ -2,35 +2,35 @@
 
 {{< include _subfiles/logistic-regression/_def-odds.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_def_conditional_odds.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_exm-odds.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_exr-odds.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_odds_fn.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_thm_est_odds_shortcut.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_thm_odds_simplified.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_thm_odds_nonevent.qmd >}}
 
----
+{{< slidebreak >}}
 
 #### Odds of rare events
 

--- a/_subfiles/logistic-regression/_sec_odds_fn.qmd
+++ b/_subfiles/logistic-regression/_sec_odds_fn.qmd
@@ -4,7 +4,7 @@
 Find a general formula for converting probabilities into odds.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-prob-to-odds}
 
@@ -19,7 +19,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-prob-to-odds}
 #### Odds as a function of probability
@@ -35,7 +35,7 @@ $$\odds = \frac{\prob}{1-\prob}$${#eq-odds-prob}
 By @sol-prob-to-odds.
 :::
 
----
+{{< slidebreak >}}
 
 ::: notes
 The mathematical relationship between odds $\odds$ and probabilities $\pi$, 
@@ -55,7 +55,7 @@ $$\oddsf{\pi} \eqdef \frac{\pi}{1-\pi}$$ {#eq-def-odds-fn}
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: notes
 We can use the odds function (@def-odds-fn) 
@@ -79,7 +79,7 @@ In other words,
 the odds function rescales probabilities into odds. 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -87,13 +87,13 @@ By @thm-prob-to-odds and @def-odds-fn.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-graph-odds-fn}
 Graph the odds function.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-graph-odds-fn}
 

--- a/_subfiles/logistic-regression/_sec_odds_of_rare_events.qmd
+++ b/_subfiles/logistic-regression/_sec_odds_of_rare_events.qmd
@@ -6,7 +6,7 @@ and what is the numerical difference between these two values?
 
 :::
 
----
+{{< slidebreak >}}
 
 ::::{.solution}
 $$
@@ -16,7 +16,7 @@ $$
 $$
 ::::
 
----
+{{< slidebreak >}}
 
 :::{#exr-odds-minus-probs}
 
@@ -26,7 +26,7 @@ as a function of $\pi$.
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-odds-minus-probs}
 
@@ -46,7 +46,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#thm-odds-minus-probs}
 

--- a/_subfiles/logistic-regression/_sec_odds_ratios.qmd
+++ b/_subfiles/logistic-regression/_sec_odds_ratios.qmd
@@ -6,50 +6,50 @@ Now that we have defined odds, we can introduce another way of comparing event p
 
 :::
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_def_OR.qmd >}}
 
----
+{{< slidebreak >}}
 
 There's a 1:1 mapping between probability and odds,
 and according to that mapping,
 the odds are equal between two covariate patterns
 IF and ONLY IF the probabilities are also equal between those patterns.
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_OR-ratio-ratio.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_exm-OR.qmd >}}
 
----
+{{< slidebreak >}}
 
 #### A shortcut for calculating odds ratio estimates {.smaller}
 
 {{< include _subfiles/logistic-regression/_sec-2x2-OR-shortcut.qmd >}}
 
----
+{{< slidebreak >}}
 
 #### Properties of odds ratios {#sec-OR-props}
 
 {{< include _subfiles/logistic-regression/_sec_ORs_reversible.qmd >}}
 
----
+{{< slidebreak >}}
 
 #### Odds Ratios vs Probability (Risk) Ratios {#sec-OR-RR}
 
 {{< include _subfiles/logistic-regression/_sec_OR-RR.qmd >}}
 
----
+{{< slidebreak >}}
 
 #### Odds Ratios in Case-Control Studies {#sec-CC-studies}
 
 {{< include _subfiles/logistic-regression/_sec_ORs-in-case-control_studies.qmd >}}
 
----
+{{< slidebreak >}}
 
 #### Odds Ratios in Cross-Sectional Studies
 

--- a/_subfiles/logistic-regression/_sec_odds_ratios.qmd
+++ b/_subfiles/logistic-regression/_sec_odds_ratios.qmd
@@ -12,23 +12,10 @@ Now that we have defined odds, we can introduce another way of comparing event p
 
 ---
 
-There's a 1:1 mapping between probability and odds, 
-and according to that mapping, 
-the odds are equal between two covariate patterns 
-IF and ONLY IF the probabilities are also equal between those patterns. 
-So, 
-testing whether an odds ratio = 1 is equivalent to 
-testing whether the corresponding risk ratio = 1, 
-and also equivalent to 
-testing whether the risk difference = 0.
-Therefore, 
-in **hypothesis testing**, 
-if the null hypothesis is no effect, 
-then we can shift between RD, RR, and OR.
-But when we're talking about **point estimates** and **CIs**, 
-we need to limit our conclusions to the effect measure(s) that we actually estimated, 
-because the *sizes* of RDs, RRs, and ORs don't have a simple relationship to each other, 
-except when pi_1=pi_2 (as shown by @fig-rd-rr-or). 
+There's a 1:1 mapping between probability and odds,
+and according to that mapping,
+the odds are equal between two covariate patterns
+IF and ONLY IF the probabilities are also equal between those patterns.
 
 ---
 

--- a/_subfiles/logistic-regression/_sec_one_cov_logistic.qmd
+++ b/_subfiles/logistic-regression/_sec_one_cov_logistic.qmd
@@ -1,6 +1,6 @@
 {{< include latex-macros/macros.qmd >}}
 
----
+{{< slidebreak >}}
 
 ::: notes
 
@@ -17,7 +17,7 @@ defined by oral contraceptive use.
 
 {{< include _subfiles/logistic-regression/_exr-bernoulli-lik.qmd >}}
 
----
+{{< slidebreak >}}
 
 ### Modeling $\pi_i$ as a function of $X_i$
 
@@ -60,7 +60,7 @@ Mortality rates of adult flour beetles after five hours’ exposure to gaseous c
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#fig-beetles_1a}
 
@@ -169,7 +169,7 @@ after five hours' exposure to gaseous carbon disulphide [@bliss1935beetles].
 
 :::
 
----
+{{< slidebreak >}}
 
 ### Three parts to regression models
 

--- a/_subfiles/logistic-regression/_sec_overview_bernoulli_models.qmd
+++ b/_subfiles/logistic-regression/_sec_overview_bernoulli_models.qmd
@@ -6,7 +6,7 @@ What is logistic regression?
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-def-logistic-regression}
 
@@ -18,7 +18,7 @@ What is logistic regression?
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: {#exr-binary-examples}
 
@@ -36,18 +36,18 @@ What are some examples of binary outcomes in the health sciences?
 
 ::::
 
----
+{{< slidebreak >}}
 
 Logistic regression uses the [Bernoulli](probability.qmd#def-bernoulli) distribution to model the outcome variable, conditional on one or more covariates.
 
----
+{{< slidebreak >}}
 
 ::: {#exr-def-bernoulli}
 
 Write down a mathematical definition of the Bernoulli distribution.
 :::
 
----
+{{< slidebreak >}}
 
 ::::{#sol-def-bernoulli}
 
@@ -55,20 +55,20 @@ Write down a mathematical definition of the Bernoulli distribution.
 
 ::::
 
----
+{{< slidebreak >}}
 
 ### Logistic regression versus linear regression
 
 Logistic regression differs from linear regression, which uses the Gaussian ("normal") distribution to model the outcome variable, conditional on the covariates.
 
----
+{{< slidebreak >}}
 
 :::: {#exr-examples-linreg}
 
 Recall: what kinds of outcomes is linear regression used for?
 ::::
 
----
+{{< slidebreak >}}
 
 ::: {#sol-examples-linreg}
 

--- a/_subfiles/logistic-regression/_sec_risk_estimation.qmd
+++ b/_subfiles/logistic-regression/_sec_risk_estimation.qmd
@@ -51,7 +51,7 @@ Simulated data from study of oral contraceptive use and heart attack risk
 
 :::::
 
----
+{{< slidebreak >}}
 
 ::::{#exr-probs}
 
@@ -74,7 +74,7 @@ $$\ph(MI|\neg OC) = \frac{7}{10000} = `r p_MI_nOC`$$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-def-controls}
 
@@ -82,7 +82,7 @@ What does the term "controls" mean in the context of study design?
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-def-controls}
 ::::{#def-controls}
@@ -96,13 +96,13 @@ Depending on context, "controls" can mean either:
 ::::
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-controls-use-cases}
 What types of studies do the two definitions of controls correspond to?
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-controls-use-cases}
 :::{#def-cases-retrospective}

--- a/_subfiles/logistic-regression/_sec_wcgs_model_graphs.qmd
+++ b/_subfiles/logistic-regression/_sec_wcgs_model_graphs.qmd
@@ -8,6 +8,8 @@ log-odds).
 
 #### probability scale
 
+:::{#fig-fitted-probs-chd}
+
 ```{r}
 curve_type_A <- function(x) { # nolint: object_name_linter
   chd_glm_contrasts |> predict(
@@ -36,9 +38,15 @@ chd_plot_probs_2 <-
 print(chd_plot_probs_2)
 ```
 
+Fitted CHD risk by age and behavior pattern (probability scale)
+
+:::
+
 ---
 
-:::{fig-fitted-odds-chd}
+#### odds scale
+
+:::{#fig-fitted-odds-chd}
 
 ```{r}
 
@@ -55,7 +63,7 @@ chd_plot_odds_2 <-
 print(chd_plot_odds_2)
 ```
 
-odds scale
+Fitted CHD odds by age and behavior pattern (odds scale)
 
 :::
 
@@ -63,8 +71,9 @@ odds scale
 
 #### log-odds (logit) scale
 
+:::{#fig-fitted-log-odds}
+
 ```{r}
-#| label: fig-fitted-log-odds
 
 chd_plot_logit_2 <-
   chd_plot_logit +
@@ -79,3 +88,7 @@ chd_plot_logit_2 <-
 
 print(chd_plot_logit_2)
 ```
+
+Fitted CHD log-odds by age and behavior pattern (log-odds scale)
+
+:::

--- a/_subfiles/logistic-regression/_sec_wcgs_model_graphs.qmd
+++ b/_subfiles/logistic-regression/_sec_wcgs_model_graphs.qmd
@@ -4,7 +4,7 @@
 We can graph our fitted models on each scale (probability, odds,
 log-odds).
 
----
+{{< slidebreak >}}
 
 #### probability scale
 
@@ -42,7 +42,7 @@ Fitted CHD risk by age and behavior pattern (probability scale)
 
 :::
 
----
+{{< slidebreak >}}
 
 #### odds scale
 
@@ -67,7 +67,7 @@ Fitted CHD odds by age and behavior pattern (odds scale)
 
 :::
 
----
+{{< slidebreak >}}
 
 #### log-odds (logit) scale
 

--- a/_subfiles/logistic-regression/_sec_wcgs_notation.qmd
+++ b/_subfiles/logistic-regression/_sec_wcgs_notation.qmd
@@ -1,4 +1,4 @@
-For the `wgcs` dataset, let's consider a **logistic regression model** for the outcome of
+For the `wcgs` dataset, let's consider a **logistic regression model** for the outcome of
 Coronary Heart Disease ($Y$; `chd` in computer output):
 
 - $Y = 1$ if an individual developed CHD by the end of the study;

--- a/_subfiles/logistic-regression/_thm_est_odds_shortcut.qmd
+++ b/_subfiles/logistic-regression/_thm_est_odds_shortcut.qmd
@@ -11,7 +11,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -43,7 +43,7 @@ without needing to compute $\hat\pi$ and $1-\hat\pi$ first.
 
 :::
 
----
+{{< slidebreak >}}
 
 ::::{#exm-odds-shortcut}
 
@@ -60,7 +60,7 @@ Let's recalculate this result using our shortcut.
 
 ::::
 
----
+{{< slidebreak >}}
 
 ::::{#sol-odds-shortcut}
 $$

--- a/_subfiles/logistic-regression/_thm_est_odds_shortcut.qmd
+++ b/_subfiles/logistic-regression/_thm_est_odds_shortcut.qmd
@@ -3,7 +3,7 @@
 
 Let $X_1,...X_n$ be a set of $n$ $\iid$ Bernoulli trials, and let $X = \sumin X_i$ be their sum.
 
-Then the maximum likelihood estimate of the odds of $X=1$, $\odds$, is:
+Then the maximum likelihood estimate of the common per-trial success odds $\odds$ (that is, the odds of $X_i=1$) is:
 
 $$
 \hat{\odds}= \frac{x}{n-x}

--- a/_subfiles/logistic-regression/_thm_odds-from-logodds.qmd
+++ b/_subfiles/logistic-regression/_thm_odds-from-logodds.qmd
@@ -11,7 +11,7 @@ $$\odds = \expf{\logodds}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 Start from @def-logodds and solve for $\odds$.

--- a/_subfiles/logistic-regression/_thm_odds_nonevent.qmd
+++ b/_subfiles/logistic-regression/_thm_odds_nonevent.qmd
@@ -1,7 +1,7 @@
 :::{#cor-odds-neg}
 #### Odds of a non-event
 
-If $\pi$ is the odds of event $A$
+If $\pi$ is the probability of event $A$
 and $\odds$ is the corresponding odds of $A$,
 then the odds of $\neg A$ are:
 

--- a/_subfiles/logistic-regression/_thm_odds_nonevent.qmd
+++ b/_subfiles/logistic-regression/_thm_odds_nonevent.qmd
@@ -14,7 +14,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 Left to the reader.

--- a/_subfiles/logistic-regression/_thm_odds_simplified.qmd
+++ b/_subfiles/logistic-regression/_thm_odds_simplified.qmd
@@ -15,13 +15,13 @@ $$ {#eq-odds-reduced}
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#exr-odds2}
 Prove @thm-odds-simplified.
 :::
 
----
+{{< slidebreak >}}
 
 :::{#sol-odds2}
 Starting from @def-odds-fn:

--- a/_subfiles/logistic-regression/_thms-deriv-odds.qmd
+++ b/_subfiles/logistic-regression/_thms-deriv-odds.qmd
@@ -4,7 +4,7 @@
 $$\doddsf{\prob} = \derivf{\odds}{\prob} = \frac{1}{\sqf{1-\prob}}$$
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 
@@ -26,7 +26,7 @@ $$
 
 :::
 
----
+{{< slidebreak >}}
 
 :::{#cor-deriv-odds}
 
@@ -36,7 +36,7 @@ $$\derivf{\odds}{\prob} = \sqf{1+\odds}$$
 
 :::
 
----
+{{< slidebreak >}}
 
 ::: proof
 

--- a/chapters/logistic-regression.qmd
+++ b/chapters/logistic-regression.qmd
@@ -48,11 +48,11 @@ This content is adapted from:
 
 {{< include _subfiles/logistic-regression/_sec_logistic_slope_mean.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_derivs_MLE.qmd >}}
 
----
+{{< slidebreak >}}
 
 {{< include _subfiles/logistic-regression/_sec_OR_logistic.qmd >}}
 


### PR DESCRIPTION
Closes #1025. Part of #1023 (workstream 2 of 9). **Stacked on #1033** — merge that PR into this branch first, or merge #1033 and this PR retargets to `main`.

Per `CLAUDE.md`, bare `---` and `{{&lt; slidebreak &gt;}}` are not equivalent: `---` renders a visible `&lt;hr&gt;` in every profile (website, book, PDF handout) while the shortcode only produces a rule in revealjs. This chapter predated the convention: the rendered page contained **248 `&lt;hr&gt;` elements**, confirmed as stray rules on the live site.

Mechanical sweep:
- All bare `---` separator lines in `_subfiles/logistic-regression/*.qmd` (54 files now use the shortcode; 46 files changed in this diff) and the two include-separators in `chapters/logistic-regression.qmd` (lines 51/55). YAML fences untouched.
- A collapse pass for consecutive doubled slidebreaks ran but found nothing to collapse — the diff is an exact 1:1 swap (240 lines removed / 240 added).
- Verified no replacements landed inside code fences (awk scan over every changed file).

Verification: chapter renders clean to HTML; `&lt;hr&gt;` count dropped **248 → 8**, and the remaining 8 are 4 navbar dropdown dividers plus 4 from shared includes outside this subtree (`chapters/r-config.qmd` still has one bare `---`; it's shared by every chapter, so it's left out of scope here rather than triggering a whole-book re-render in this PR). Lint: 63 hits across the changed files, all pre-existing (this diff changes no R code). Spellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce