### PR TITLE
publish.yml: raise Deno V8 heap cap to 12 GB for the full-site render

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,16 @@ jobs:
 
       - name: Render
         uses: quarto-dev/quarto-actions/render@v2
+        env:
+          # Quarto's launcher caps Deno at an 8 GB V8 heap by default and
+          # appends this env var's flags after its own, so the later
+          # duplicate wins (V8 parses flags last-wins). The full site render
+          # now exceeds 8 GB of cumulative heap and crashes with
+          # "Fatal JavaScript out of memory" (exit 133) without this;
+          # 12 GB of the runner's 16 GB leaves headroom for R and the OS.
+          # Same fix as gha#263 applies to the PR preview builds; this
+          # bespoke workflow needs it set directly (rme#1044).
+          QUARTO_DENO_V8_OPTIONS: --max-old-space-size=12288,--max-heap-size=12288
 
       - name: Save Quarto freeze
         if: github.ref_name == 'main'


### PR DESCRIPTION
Closes #1044.

`Quarto Publish` on `main` fails at the Render step since the #1023 stack merged ([run 29559535635](https://github.com/d-morrison/rme/actions/runs/29559535635/job/87818835913), head `27463a95`): the identical Deno out-of-memory crash diagnosed for the PR preview builds in [gha#262](https://github.com/d-morrison/gha/issues/262) — `Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit` at ~8,132 MB, exit code 133. The publish render is even larger than the preview builds' (it also runs the PDF/book profiles), so the grown site pushed it past Quarto's hardcoded 8 GB V8 heap default.

[gha#263](https://github.com/d-morrison/gha/pull/263) fixed this for every consumer of the `preview` and `quarto-publish` composites (both formerly-failing rme PR builds went green under it), but `publish.yml` is a bespoke workflow with its own `quarto-dev/quarto-actions/render@v2` step, so it needs `QUARTO_DENO_V8_OPTIONS=--max-old-space-size=12288,--max-heap-size=12288` set directly. The mechanism (Quarto's launcher appends user flags after its defaults inside one `--v8-flags=` argument; V8 applies the last occurrence) was verified against the launcher script and empirically against Quarto's bundled Deno binary during the gha#263 work.

One-step, workflow-only change per this repo's "workflow changes go in their own dedicated PRs" rule. After merge, re-running the failed publish run should turn `main`'s deploy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce

---
_Generated by [Claude Code](https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce)_