### PR TITLE
publish.yml: render each format separately to bound Deno heap growth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,17 +53,30 @@ jobs:
         shell: bash
 
       - name: Render
-        uses: quarto-dev/quarto-actions/render@v2
         env:
           # Quarto's launcher caps Deno at an 8 GB V8 heap by default and
           # appends this env var's flags after its own, so the later
-          # duplicate wins (V8 parses flags last-wins). The full site render
-          # now exceeds 8 GB of cumulative heap and crashes with
-          # "Fatal JavaScript out of memory" (exit 133) without this;
-          # 12 GB of the runner's 16 GB leaves headroom for R and the OS.
-          # Same fix as gha#263 applies to the PR preview builds; this
-          # bespoke workflow needs it set directly (rme#1044).
+          # duplicate wins (V8 parses flags last-wins). Without a raised cap
+          # the site render crashes with "Fatal JavaScript out of memory"
+          # (exit 133); 12 GB of the runner's 16 GB leaves headroom for R,
+          # LaTeX, and the OS (rme#1044, same mechanism as gha#263).
           QUARTO_DENO_V8_OPTIONS: --max-old-space-size=12288,--max-heap-size=12288
+        shell: bash
+        # One `quarto render` of the website profile builds every page in
+        # all four of its formats (html, revealjs, pdf, docx) inside a
+        # single Deno process, and the heap accumulates across those ~150
+        # document renders — it blew through 12 GB after exceeding the old
+        # 8 GB cap (rme#1044). Render each format as its own invocation
+        # instead, resetting the Deno heap between formats — the same
+        # per-format split gha's `preview` composite uses, which is why the
+        # PR preview builds fit comfortably under the same cap.
+        # `--no-clean` keeps earlier formats' output in _site.
+        run: |
+          set -euo pipefail
+          quarto render --to pdf
+          quarto render --to docx --no-clean
+          quarto render --to revealjs --no-clean
+          quarto render --to html --no-clean
 
       - name: Save Quarto freeze
         if: github.ref_name == 'main'


### PR DESCRIPTION
Closes #1044 (reopened — the #1045 cap raise was necessary but not sufficient).

**What the post-merge run proved:** [run 29615602325](https://github.com/d-morrison/rme/actions/runs/29615602325/job/87999905159) crashed with the same OOM signature but at **12,090 MB** (previously 8,132 MB) — the `QUARTO_DENO_V8_OPTIONS` override from #1045 took effect exactly as designed, and the publish render simply needs more heap than any single process can safely have on a 16 GB runner (a 14 GB cap would leave ~2 GB for R chunk evaluation, LuaLaTeX, and the OS, and re-breaks as the site grows).

**Root cause of the difference from the PR previews:** the publish's single `quarto render` builds every page in **all four** website-profile formats (`html`, `revealjs`, `pdf`, `docx` — the run log shows e.g. `exam-formula-sheet.qmd` knitting multiple times in a row) inside one Deno process, ~150 document renders with cumulative heap. The PR preview builds stay green under the identical 12 GB cap because gha's `preview` composite renders each format as a **separate `quarto render` invocation**, resetting the heap between formats.

**Change:** replace the single `quarto-actions/render@v2` call with the same per-format split, keeping the 12 GB env for each pass:

```bash
quarto render --to pdf
quarto render --to docx --no-clean
quarto render --to revealjs --no-clean
quarto render --to html --no-clean
```

`--no-clean` preserves earlier formats' output in `_site` (same flag gha's composite uses); the deploy step is untouched. Output set is identical to the combined render's. This bounds per-process heap regardless of future site growth, rather than chasing the cap upward.

Workflow-only change per the dedicated-infra-PR rule. Note: as with #1045, the required `build / build` check won't run on this diff (preview path filter), so the merge needs the admin override again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce

---
_Generated by [Claude Code](https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce)_