### PR TITLE
Fix publish-render warnings: docx TeX math, cross-chapter crossref, Code of Conduct link

### DIFF
--- a/_subfiles/math-prereqs/_sec_linear_algebra.qmd
+++ b/_subfiles/math-prereqs/_sec_linear_algebra.qmd
@@ -739,7 +739,8 @@ They occur frequently in statistics:
 
 - The residual sum of squares in linear regression (@sec-vector-calculus)
   is a quadratic form.
-- The variance of a linear combination of estimates (@sec-infer-LMs)
+- The variance of a linear combination of estimates
+  (see [Inference about Gaussian Linear Regression Models](Linear-models-overview.qmd#sec-infer-LMs))
   is a quadratic form:
   $\Var{\tp{\vx}\hat{\vb}} = \tp{\vx}\,\Var{\hat{\vb}}\,\vx$.
 :::

--- a/_subfiles/predictor-selection/_sec-pred-sel-prediction.qmd
+++ b/_subfiles/predictor-selection/_sec-pred-sel-prediction.qmd
@@ -140,8 +140,10 @@ and BA and $J$ are equivalent for comparing models.
 
 **C-statistic** (area under the ROC curve, AUC):
 $$
-C = \Pr(\hat{\pi}_i > \hat{\pi}_j \mid Y_i = 1, Y_j = 0) \\
-\qquad + \frac{1}{2}\Pr(\hat{\pi}_i = \hat{\pi}_j \mid Y_i = 1, Y_j = 0)
+\ba
+C \eqdef {} & \Pr(\hat{\pi}_i > \hat{\pi}_j \mid Y_i = 1, Y_j = 0) \\
+& + \frac{1}{2}\Pr(\hat{\pi}_i = \hat{\pi}_j \mid Y_i = 1, Y_j = 0)
+\ea
 $$
 where $\hat{\pi}$ is the predicted event probability.
 An empirical estimator is
@@ -152,7 +154,7 @@ $$
 \sum_{j:Y_j=0}
 \left[
 I(\hat{\pi}_i > \hat{\pi}_j)
-\qquad + \frac{1}{2}I(\hat{\pi}_i = \hat{\pi}_j)
++ \frac{1}{2}I(\hat{\pi}_i = \hat{\pi}_j)
 \right].
 $$
 It measures discrimination:

--- a/chapters/CONTRIBUTING.qmd
+++ b/chapters/CONTRIBUTING.qmd
@@ -62,7 +62,7 @@ Details at <https://usethis.r-lib.org/articles/pr-functions.html>
 # Code of Conduct
 
 Please note that the `rme` project is released with a
-[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this
+[Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). By contributing to this
 project you agree to abide by its terms.
 
 # Additional references


### PR DESCRIPTION
Closes #1047.

Fixes all three warnings from the Render step of the first green publish run ([run 29619319070, job 88011006349](https://github.com/d-morrison/rme/actions/runs/29619319070/job/88011006349)), including the TeX-math conversion failure flagged at [step 10 line 8366](https://github.com/d-morrison/rme/actions/runs/29619319070/job/88011006349#step:10:8366):

1. **`Could not convert TeX math` (docx pass)** — the C-statistic definition in `_subfiles/predictor-selection/_sec-pred-sel-prediction.qmd` used a bare `\\` line break in display math with no alignment environment; Pandoc's texmath parser rejects that (`unexpected control sequence \\`) and falls back to literal TeX in the Word output. Wrapped the two lines in `\ba`/`\ea` (aligned), switched the defining `=` to `\eqdef` per the repo's math conventions, and removed the stray `\qquad` left in the companion empirical-estimator formula by the same two-line formatting attempt.
2. **`Unable to resolve crossref @sec-infer-LMs` (3x, math-prereqs, one per docx/revealjs/html pass)** — `_subfiles/math-prereqs/_sec_linear_algebra.qmd` referenced `@sec-infer-LMs`, which is defined in `chapters/Linear-models-overview.qmd`; `@id` doesn't resolve across chapters in a Quarto website project, so the reference rendered broken. Replaced with an explicit `[text](Linear-models-overview.qmd#sec-infer-LMs)` link per the repo's cross-chapter convention.
3. **`Unable to resolve link target: chapters/CODE_OF_CONDUCT.md` (2x)** — `chapters/CONTRIBUTING.qmd` linked `CODE_OF_CONDUCT.md` relative to `chapters/`; the file lives at the repo root and isn't in the site render list, so the link was broken on the published site. Now links the Contributor Covenant 2.1 page, matching the identical sentence in `README.md`.

**Verification (pre-commit gate):**

- `quarto render chapters/predictor-selection.qmd --to html` ✅ and `--to docx` ✅ — the docx pass (the format that warned) now completes with **zero** `Could not convert TeX math` warnings.
- `quarto render chapters/math-prereqs.qmd --to html` ✅ — no `Unable to resolve crossref` warning (it previously fired on every render of this chapter).
- `quarto render chapters/CONTRIBUTING.qmd --to html` ✅.
- `lintr::lint()` on all three changed files: no lints.
- `spelling::spell_check_package()`: no errors.

`_subfiles/` were edited, so the **clear freezer** label applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce

---
_Generated by [Claude Code](https://claude.ai/code/session_013p49KvCbycnFLoSxh66dce)_