### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/check-equation-renders.yml
+++ b/.github/workflows/check-equation-renders.yml
@@ -1,5 +1,5 @@
 # Fourth leg of the PR-preview family, delegated to the reusable workflow in
-# d-morrison/gha. Triggered when the build workflow finishes, it downloads the
+# Morrison-Lab/gha. Triggered when the build workflow finishes, it downloads the
 # build artifact and crawls it with a headless browser to catch equations
 # MathJax can't render -- invisible in the Quarto/pandoc build log, since
 # MathJax only typesets client-side (see d-morrison/rme#972).
@@ -19,4 +19,4 @@ jobs:
     permissions:
       contents: read
       actions: read  # needed to download the build artifact
-    uses: d-morrison/gha/.github/workflows/check-equation-renders.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-equation-renders.yml@v2

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-# Thin caller of the canonical d-morrison/gha reusable review workflow.
+# Thin caller of the canonical Morrison-Lab/gha reusable review workflow.
 #
 # Keep this file named claude-code-review.yml and keep the workflow_dispatch
 # `pr_number` input: claude.yml re-dispatches a review with
@@ -7,7 +7,7 @@
 # all the review logic (reviewer stash/restore, tag-vs-agent mode gating,
 # inline-comment allowlist, read-only tool guard, allowed_bots for
 # bot-dispatched runs, the is_error guard) lives in the reusable workflow.
-# See d-morrison/gha examples/claude-code-review.yml for the upstream stub.
+# See Morrison-Lab/gha examples/claude-code-review.yml for the upstream stub.
 name: Claude Code Review
 
 on:
@@ -32,7 +32,7 @@ jobs:
       issues: write
       id-token: write
       actions: read # lets the reviewer read CI status (github_ci MCP server)
-    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/claude-code-review.yml@v2
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }} # for the private latex-macros submodule

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,5 +1,5 @@
 # Housekeeping half of the PR-preview family, delegated to the reusable
-# workflow in d-morrison/gha. Periodically deletes gh-pages preview directories
+# workflow in Morrison-Lab/gha. Periodically deletes gh-pages preview directories
 # for PRs that are no longer open, and (with compact-history) orphan-squashes
 # gh-pages to a single commit so the deleted snapshots stop bloating the repo.
 # The calling job grants contents: write so the reusable workflow can commit the
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/cleanup-pr-previews.yml@v2
     with:
       compact-history: true

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,5 +1,5 @@
 # Deploy half of the PR-preview family, delegated to the reusable workflow in
-# d-morrison/gha. Triggered when the build workflow finishes, it downloads the
+# Morrison-Lab/gha. Triggered when the build workflow finishes, it downloads the
 # build artifact and publishes the preview to gh-pages. This runs in the
 # BASE-repo context, so its token can write — keeping it separate from the
 # read-only build half is the trust boundary.
@@ -21,4 +21,4 @@ jobs:
       contents: write        # push to gh-pages
       pull-requests: write   # post the preview-link comment
       actions: read          # download the build artifact
-    uses: d-morrison/gha/.github/workflows/preview-deploy.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/preview-deploy.yml@v2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,5 +1,5 @@
 # Build half of the PR-preview family, delegated to the reusable workflow in
-# d-morrison/gha. Renders the Quarto site in the (possibly fork) PR context and
+# Morrison-Lab/gha. Renders the Quarto site in the (possibly fork) PR context and
 # uploads it + PR metadata as an artifact; the deploy half (preview-deploy.yml)
 # publishes it to gh-pages. This job is read-only (contents: read) — it must
 # never write to the base repo.
@@ -39,6 +39,6 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: d-morrison/gha/.github/workflows/preview.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/preview.yml@v2
     with:
       r-version: '4.6.0'


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 11 reference(s) across 5 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.