### PR TITLE
Add Cameron, Gelbach & Miller (2011) multiway-clustering reference

### DIFF
--- a/chapters/other-resources.qmd
+++ b/chapters/other-resources.qmd
@@ -146,6 +146,16 @@ and related computational sciences.
 "Stats 202" at Stanford University, covering regression, classification,
 cross-validation, and other statistical and machine learning topics.
 
+- @cameron2011robust proposes a variance estimator extending
+one-way cluster-robust ("sandwich") standard errors
+to two-way or multiway non-nested clustering
+(e.g., clustering by both firm and year and their intersection),
+for OLS as well as nonlinear estimators like logit, probit, and GMM.
+It is the standard reference for multiway-clustered standard errors
+in applied econometrics
+and is easily implemented in any package that already supports
+one-way cluster-robust standard errors.
+
 ### Machine Learning
 
 {{< include _subfiles/other-resources/_sec-machine-learning.qmd >}}

--- a/references.bib
+++ b/references.bib
@@ -1908,3 +1908,15 @@ url={https://onlinelibrary.wiley.com/doi/book/10.1002/9780470580066}
   isbn={9780521574716},
   url={https://doi.org/10.1017/CBO9780511802843}
 }
+
+@article{cameron2011robust,
+  title={Robust Inference With Multiway Clustering},
+  author={Cameron, A. Colin and Gelbach, Jonah B. and Miller, Douglas L.},
+  journal={Journal of Business \& Economic Statistics},
+  volume={29},
+  number={2},
+  pages={238--249},
+  year={2011},
+  doi={10.1198/jbes.2010.07136},
+  url={https://doi.org/10.1198/jbes.2010.07136}
+}


### PR DESCRIPTION
## Summary
- Adds a bib entry (`cameron2011robust`) for Cameron, Gelbach & Miller (2011), "Robust Inference With Multiway Clustering," *Journal of Business & Economic Statistics* 29(2), 238-249. https://doi.org/10.1198/jbes.2010.07136
- Adds an annotated bullet for it in `chapters/other-resources.qmd`, summarizing what it does and why it's the standard reference for multiway-clustered standard errors.

## Test plan
- [x] `quarto render chapters/other-resources.qmd --to html` — renders cleanly, no errors; citation resolves consistently with all other citations in the file (unresolved `@citekey` spans in this standalone single-file render mode, matching every pre-existing citation in the file)
- [x] `Rscript -e 'lintr::lint("chapters/other-resources.qmd")'` — no lints
- [x] `Rscript -e 'spelling::spell_check_package()'` — no spelling errors
- [x] Diff scanned for banned non-ASCII punctuation (em/en-dash, curly quotes) — none introduced